### PR TITLE
implement HS feedback

### DIFF
--- a/packages/datasets/src/treeGeneration/databaseNlQueries/databaseNodes/generateNaturalLanguageQueries.atlasSearch.eval.ts
+++ b/packages/datasets/src/treeGeneration/databaseNlQueries/databaseNodes/generateNaturalLanguageQueries.atlasSearch.eval.ts
@@ -22,6 +22,8 @@ const openAiClient = wrapOpenAI(
   })
 );
 
+const atlasSearchLabel = "atlas_search";
+
 const evalData = useCaseNodes.map((useCase) => {
   const databaseInfo = useCase.parent.parent.data;
   const user = useCase.parent.data;
@@ -37,7 +39,7 @@ const evalData = useCaseNodes.map((useCase) => {
       user: user.name,
       useCase: useCase.data.title,
     },
-    tags: ["atlas_search"],
+    tags: [atlasSearchLabel],
   };
 });
 
@@ -49,7 +51,6 @@ const llmOptions: LlmOptions = {
 };
 
 async function main() {
-  console.log("evalData", evalData.length);
   await Eval("generate-atlas-search-natural-language", {
     experimentName: `atlas-search-enhanced-prompt-evaluation-${llmOptions.model}`,
     data: evalData,
@@ -58,7 +59,7 @@ async function main() {
     async task(input) {
       const promptMessages = makeGenerateNaturalLanguageQueryPrompt({
         ...input,
-        queryType: "atlas_search", // Ensure we use Atlas Search prompts
+        queryType: atlasSearchLabel, // Ensure we use Atlas Search prompts
       });
       const { results } = await getOpenAiFunctionResponse({
         messages: promptMessages,

--- a/packages/datasets/src/treeGeneration/databaseNlQueries/databaseNodes/sampleData/atlasSearch.ts
+++ b/packages/datasets/src/treeGeneration/databaseNlQueries/databaseNodes/sampleData/atlasSearch.ts
@@ -134,7 +134,6 @@ export const sampleDatabaseUsers = [
   },
 ] as const satisfies DatabaseUser[];
 
-// TODO: update
 export const sampleUseCases = {
   "Yuki Tanaka": [
     {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1231

## Changes
- Generate Atlas Search Dataset: [atlas-search-dataset-gpt-5](https://www.braintrust.dev/app/mongodb-education-ai/p/natural-language-to-atlas-search/datasets/atlas-search-dataset-gpt-5)
- Prompt refinement on generate Atlas Search dataset pipeline
- More robust err handling in tool calls
- Add GPT-5 and Claude 4 models to benchmarking set. Add dataset to benchmark.