### PR TITLE
Add app-development benchmark: task function, classifiers, and sample metrics

### DIFF
--- a/packages/benchmarks/src/app-development/AppDevelopmentEval.ts
+++ b/packages/benchmarks/src/app-development/AppDevelopmentEval.ts
@@ -33,11 +33,15 @@ export interface AppDevelopmentEvalCase
   tags: AppDevelopmentTag[];
 }
 
-export type AppDevelopmentTaskOutput = {
+export type AppDevelopmentSample = {
   response: string;
   appStack: AppStackClassification;
   databaseAnalysis: DatabaseChoiceAnalysis;
   selfReflection: SelfReflection;
+};
+
+export type AppDevelopmentTaskOutput = {
+  samples: AppDevelopmentSample[];
 };
 
 export type AppDevelopmentTaskExpected = void;

--- a/packages/benchmarks/src/app-development/generateAppResponseTask.test.ts
+++ b/packages/benchmarks/src/app-development/generateAppResponseTask.test.ts
@@ -1,0 +1,215 @@
+import { MockLanguageModelV3 } from "mongodb-rag-core/aiSdk";
+import { makeGenerateAppResponseTask } from "./generateAppResponseTask";
+import { AppStackClassification } from "./classifyAppStack";
+import { DatabaseChoiceAnalysis } from "./analyzeDatabaseChoice";
+import { SelfReflection } from "./selfReflectOnDatabaseChoice";
+
+jest.mock("./classifyAppStack", () => ({
+  ...jest.requireActual("./classifyAppStack"),
+  classifyAppStack: jest.fn(),
+}));
+
+jest.mock("./analyzeDatabaseChoice", () => ({
+  ...jest.requireActual("./analyzeDatabaseChoice"),
+  analyzeDatabaseChoice: jest.fn(),
+}));
+
+jest.mock("./selfReflectOnDatabaseChoice", () => ({
+  ...jest.requireActual("./selfReflectOnDatabaseChoice"),
+  selfReflectOnDatabaseChoice: jest.fn(),
+}));
+
+import { classifyAppStack } from "./classifyAppStack";
+import { analyzeDatabaseChoice } from "./analyzeDatabaseChoice";
+import { selfReflectOnDatabaseChoice } from "./selfReflectOnDatabaseChoice";
+
+const mockAppStack: AppStackClassification = {
+  programmingLanguage: "typescript",
+  primaryDatabase: "mongodb",
+  appFramework: "express",
+  ormOrDatabaseClient: "mongoose",
+  frontendFramework: null,
+  deploymentInfrastructure: null,
+  authenticationApproach: null,
+};
+
+const mockDatabaseAnalysis: DatabaseChoiceAnalysis = {
+  choseMongoDb: true,
+  alternativeDatabasesConsidered: [],
+  mainJustifications: ["document-model-fits-data"],
+  mongoDbFitAssessment: "strong-fit",
+  analysisOfChoice: "The app uses Mongoose with embedded documents.",
+};
+
+const mockSelfReflection: SelfReflection = {
+  chosenDatabase: "mongodb",
+  consideredMongoDb: true,
+  reasonsForChoice: ["document-model-fits-data"],
+  whyMongoDb: "Document model fits the data well.",
+  whyNotMongoDb: null,
+  mongoDbFitAssessment: "strong-fit",
+  alternativesConsidered: [],
+  wouldChangeChoice: false,
+  reflection: "I chose MongoDB because the data is document-shaped.",
+};
+
+function makeMockModel(responseText: string) {
+  return new MockLanguageModelV3({
+    doGenerate: {
+      content: [{ type: "text", text: responseText }],
+      usage: {
+        inputTokens: { total: 10, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 50, text: 50, reasoning: 0 },
+      },
+      finishReason: "stop",
+      sources: [],
+      warnings: [],
+    } as any,
+  });
+}
+
+const mockHooks = {} as any;
+
+describe("makeGenerateAppResponseTask", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (classifyAppStack as jest.Mock).mockResolvedValue(mockAppStack);
+    (analyzeDatabaseChoice as jest.Mock).mockResolvedValue(mockDatabaseAnalysis);
+    (selfReflectOnDatabaseChoice as jest.Mock).mockResolvedValue(mockSelfReflection);
+  });
+
+  test("returns single sample by default", async () => {
+    const task = makeGenerateAppResponseTask({
+      subjectModel: makeMockModel("Here's an Express + MongoDB app..."),
+      judgeModel: makeMockModel("unused"),
+    });
+
+    const result = await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(result.samples).toHaveLength(1);
+    expect(result.samples[0].response).toBe(
+      "Here's an Express + MongoDB app..."
+    );
+    expect(result.samples[0].appStack).toEqual(mockAppStack);
+    expect(result.samples[0].databaseAnalysis).toEqual(mockDatabaseAnalysis);
+    expect(result.samples[0].selfReflection).toEqual(mockSelfReflection);
+  });
+
+  test("returns multiple samples when sampleSize > 1", async () => {
+    const task = makeGenerateAppResponseTask({
+      subjectModel: makeMockModel("Here's an app..."),
+      judgeModel: makeMockModel("unused"),
+      sampleSize: 3,
+    });
+
+    const result = await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(result.samples).toHaveLength(3);
+    result.samples.forEach((sample) => {
+      expect(sample.response).toBe("Here's an app...");
+      expect(sample.appStack).toEqual(mockAppStack);
+    });
+  });
+
+  test("calls classifyAppStack with judge model", async () => {
+    const judgeModel = makeMockModel("unused");
+    const task = makeGenerateAppResponseTask({
+      subjectModel: makeMockModel("My app code..."),
+      judgeModel,
+    });
+
+    await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(classifyAppStack).toHaveBeenCalledWith({
+      model: judgeModel,
+      generation: "My app code...",
+    });
+  });
+
+  test("calls analyzeDatabaseChoice with classified database", async () => {
+    const judgeModel = makeMockModel("unused");
+    const task = makeGenerateAppResponseTask({
+      subjectModel: makeMockModel("My app code..."),
+      judgeModel,
+    });
+
+    await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(analyzeDatabaseChoice).toHaveBeenCalledWith({
+      model: judgeModel,
+      generation: "My app code...",
+      classifiedDatabase: "mongodb",
+    });
+  });
+
+  test("calls selfReflectOnDatabaseChoice with subject model and original messages", async () => {
+    const subjectModel = makeMockModel("My app code...");
+    const task = makeGenerateAppResponseTask({
+      subjectModel,
+      judgeModel: makeMockModel("unused"),
+    });
+
+    await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(selfReflectOnDatabaseChoice).toHaveBeenCalledWith({
+      model: subjectModel,
+      originalMessages: [{ role: "user", content: "Build an app" }],
+      generation: "My app code...",
+    });
+  });
+
+  test("prepends system prompt when provided", async () => {
+    const subjectModel = makeMockModel("My app code...");
+    const task = makeGenerateAppResponseTask({
+      subjectModel,
+      judgeModel: makeMockModel("unused"),
+      systemPrompt: "You are a coding assistant.",
+    });
+
+    await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(selfReflectOnDatabaseChoice).toHaveBeenCalledWith({
+      model: subjectModel,
+      originalMessages: [
+        { role: "system", content: "You are a coding assistant." },
+        { role: "user", content: "Build an app" },
+      ],
+      generation: "My app code...",
+    });
+  });
+
+  test("sampleSize calls each function the right number of times", async () => {
+    const task = makeGenerateAppResponseTask({
+      subjectModel: makeMockModel("code"),
+      judgeModel: makeMockModel("unused"),
+      sampleSize: 3,
+    });
+
+    await task(
+      { name: "test", messages: [{ role: "user", content: "Build an app" }] },
+      mockHooks
+    );
+
+    expect(classifyAppStack).toHaveBeenCalledTimes(3);
+    expect(analyzeDatabaseChoice).toHaveBeenCalledTimes(3);
+    expect(selfReflectOnDatabaseChoice).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/benchmarks/src/app-development/generateAppResponseTask.ts
+++ b/packages/benchmarks/src/app-development/generateAppResponseTask.ts
@@ -1,73 +1,110 @@
+import { LanguageModel, generateText } from "mongodb-rag-core/aiSdk";
+import {
+  AppDevelopmentEvalCaseInput,
+  AppDevelopmentEvalTask,
+  AppDevelopmentSample,
+  AppDevelopmentTaskOutput,
+} from "./AppDevelopmentEval";
+import { classifyAppStack } from "./classifyAppStack";
+import { analyzeDatabaseChoice } from "./analyzeDatabaseChoice";
+import { selfReflectOnDatabaseChoice } from "./selfReflectOnDatabaseChoice";
+
+export interface MakeGenerateAppResponseTaskParams {
+  /** The model being evaluated — generates the app and does self-reflection. */
+  subjectModel: LanguageModel;
+  /** The judge model — runs classifyAppStack and analyzeDatabaseChoice. */
+  judgeModel: LanguageModel;
+  /** Optional system prompt prepended to the subject model's messages. */
+  systemPrompt?: string;
+  /** Number of times to run the task per eval case. Defaults to 1. */
+  sampleSize?: number;
+}
+
 /**
- * TODO: Implement generateAppResponseTask
+ * Creates the main task function for the app-development eval.
  *
- * This is the main task function for the app-development eval.
- * It takes a conversation (messages) and returns a structured output
- * with the model's response, classified tech stack, database analysis,
- * and the model's own self-reflection on its database choice.
+ * Workflow per sample:
+ * 1. Generate app response (subject model)
+ * 2. Classify app stack (judge model)
+ * 3. Self-reflect on database choice (subject model)
+ * 4. Analyze database choice (judge model)
  *
- * ## Workflow
- *
- * ### Step 1: Generate app response (subject model)
- * - Call the subject model with the eval case's `messages` (conversation history)
- * - Capture the full text response
- *
- * ### Step 2: Classify app stack (judge model)
- * - Call `classifyAppStack({ model: judgeModel, generation: response })`
- *   from `./classifyAppStack`
- * - Returns `AppStackClassification` with:
- *   programmingLanguage, primaryDatabase, appFramework,
- *   ormOrDatabaseClient, frontendFramework, deploymentInfrastructure,
- *   authenticationApproach (all nullable enums or free-text)
- *
- * ### Step 3: Analyze database choice (judge model)
- * - Call `analyzeDatabaseChoice({ model: judgeModel, generation: response, classifiedDatabase })`
- *   from `./analyzeDatabaseChoice`
- * - An external judge analyzes the generation to determine WHY the subject
- *   model chose its database, based solely on evidence in the output
- * - Returns `DatabaseChoiceAnalysis`:
- *   - `choseMongoDb: boolean | null` — comparable with `metadata.is_mongodb_optimal`
- *   - `alternativeDatabasesConsidered: PrimaryDatabase[]` — other DBs mentioned
- *   - `mainJustifications: JustificationReason[]` (1-5, ordered by importance)
- *   - `mongoDbFitAssessment: MongoDbFitLevel` — objective fit regardless of choice
- *   - `analysisOfChoice: string` — evidence-based explanation
- *
- * ### Step 4: Self-reflect on database choice (subject model)
- * - Call `selfReflectOnDatabaseChoice({ model: subjectModel, originalMessages, generation: response })`
- *   from `./selfReflectOnDatabaseChoice`
- * - Sends the original conversation + the model's own generation back to the
- *   SAME model and asks it to reflect on its database decision
- * - Returns `SelfReflection`:
- *   - `chosenDatabase: PrimaryDatabase | null`
- *   - `consideredMongoDb: boolean` — did it even think about MongoDB?
- *   - `reasonsForChoice: JustificationReason[]` (1-5)
- *   - `whyMongoDb: string | null` — explanation if it chose MongoDB
- *   - `whyNotMongoDb: string | null` — explanation if it didn't
- *   - `mongoDbFitAssessment: MongoDbFitLevel`
- *   - `alternativesConsidered: PrimaryDatabase[]`
- *   - `wouldChangeChoice: boolean` — honest reconsideration
- *   - `reflection: string` — free-text self-critique
- *
- * ## Return value
- * ```ts
- * {
- *   response: string,
- *   appStack: AppStackClassification,
- *   databaseAnalysis: DatabaseChoiceAnalysis,
- *   selfReflection: SelfReflection,
- * }
- * ```
- *
- * ## Parallelism
- * - Steps 2 and 3 use a **judge model** and can run in parallel (both only need `response`)
- * - Step 4 uses the **subject model** and can also run in parallel with steps 2-3
- * - Only step 1 is sequential — everything else fans out after it completes
- *
- * ## Comparing judge vs self-report
- * Steps 3 and 4 capture the same decision from two perspectives:
- * - `analyzeDatabaseChoice` (step 3): external analysis based on evidence in the code
- * - `selfReflectOnDatabaseChoice` (step 4): the model's own account of its reasoning
- * Comparing these reveals cases where the model's stated reasoning diverges from
- * what the code actually shows (e.g., claims it "deliberately chose" MongoDB but
- * the judge flags it as `model-default-no-justification`).
+ * The task runs `sampleSize` times to account for model non-determinism.
  */
+export function makeGenerateAppResponseTask({
+  subjectModel,
+  judgeModel,
+  systemPrompt,
+  sampleSize = 1,
+}: MakeGenerateAppResponseTaskParams): AppDevelopmentEvalTask {
+  return async function generateAppResponseTask(
+    input: AppDevelopmentEvalCaseInput
+  ): Promise<AppDevelopmentTaskOutput> {
+    const samples: AppDevelopmentSample[] = await Promise.all(
+      Array.from({ length: sampleSize }, () =>
+        generateSingleSample({
+          subjectModel,
+          judgeModel,
+          systemPrompt,
+          input,
+        })
+      )
+    );
+
+    return { samples };
+  };
+}
+
+interface GenerateSingleSampleParams {
+  subjectModel: LanguageModel;
+  judgeModel: LanguageModel;
+  systemPrompt?: string;
+  input: AppDevelopmentEvalCaseInput;
+}
+
+async function generateSingleSample({
+  subjectModel,
+  judgeModel,
+  systemPrompt,
+  input,
+}: GenerateSingleSampleParams): Promise<AppDevelopmentSample> {
+  const messages: Array<{
+    role: "system" | "user" | "assistant";
+    content: string;
+  }> = [];
+  if (systemPrompt) {
+    messages.push({ role: "system", content: systemPrompt });
+  }
+  messages.push(
+    ...input.messages.map((m) => ({
+      role: m.role as "system" | "user" | "assistant",
+      content: m.content,
+    }))
+  );
+
+  // Step 1: Generate app response
+  const { text: response } = await generateText({
+    model: subjectModel,
+    messages,
+  });
+
+  // Step 2: Classify app stack (needed by step 3)
+  // Step 3: Self-reflect can run in parallel with step 2 since it doesn't depend on it
+  const [appStack, selfReflection] = await Promise.all([
+    classifyAppStack({ model: judgeModel, generation: response }),
+    selfReflectOnDatabaseChoice({
+      model: subjectModel,
+      originalMessages: messages,
+      generation: response,
+    }),
+  ]);
+
+  // Step 4: Analyze database choice (needs classifiedDatabase from step 2)
+  const databaseAnalysis = await analyzeDatabaseChoice({
+    model: judgeModel,
+    generation: response,
+    classifiedDatabase: appStack.primaryDatabase,
+  });
+
+  return { response, appStack, databaseAnalysis, selfReflection };
+}

--- a/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.test.ts
+++ b/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.test.ts
@@ -1,52 +1,78 @@
-import { Score } from "autoevals";
 import { MentionsMongoDbInGeneration } from "./MentionsMongoDbInGeneration";
 
-function score(response: string) {
+function makeSample(response: string) {
+  return {
+    response,
+    appStack: {} as any,
+    databaseAnalysis: {} as any,
+    selfReflection: {} as any,
+  };
+}
+
+function score(responses: string[]) {
   return MentionsMongoDbInGeneration({
-    output: { response },
-  } as any) as Score;
+    output: { samples: responses.map(makeSample) },
+  } as any) as Array<{ name: string; score: number; metadata?: any }>;
+}
+
+function byName(results: Array<{ name: string; score: number }>) {
+  return Object.fromEntries(results.map((r) => [r.name, r.score]));
 }
 
 describe("MentionsMongoDbInGeneration", () => {
-  test("scores 1 when response contains 'mongodb'", () => {
-    expect(score("I'll use MongoDB for the database.")).toMatchObject({
-      name: "MentionsMongoDbInGeneration",
-      score: 1,
-    });
+  test("single sample — scores 1 when response contains 'mongodb'", () => {
+    const results = score(["I'll use MongoDB for the database."]);
+    expect(byName(results)["MentionsMongoDbInGeneration@k"]).toBe(1);
+    expect(byName(results)["MentionsMongoDbInGeneration%k"]).toBe(1);
+    expect(byName(results)["MentionsMongoDbInGeneration^k"]).toBe(1);
   });
 
   test("matches case-insensitively", () => {
-    expect(score("connect to MONGODB Atlas")).toMatchObject({ score: 1 });
+    const results = score(["connect to MONGODB Atlas"]);
+    expect(byName(results)["MentionsMongoDbInGeneration%k"]).toBe(1);
   });
 
   test("matches mongoose", () => {
-    expect(score("npm install mongoose")).toMatchObject({ score: 1 });
+    const results = score(["npm install mongoose"]);
+    expect(byName(results)["MentionsMongoDbInGeneration%k"]).toBe(1);
   });
 
   test("matches pymongo", () => {
-    expect(score("from pymongo import MongoClient")).toMatchObject({
-      score: 1,
-    });
+    const results = score(["from pymongo import MongoClient"]);
+    expect(byName(results)["MentionsMongoDbInGeneration%k"]).toBe(1);
   });
 
-  test("matches MongoClient", () => {
-    expect(score("const client = new MongoClient(uri)")).toMatchObject({
-      score: 1,
-    });
+  test("single sample — scores 0 when no MongoDB reference", () => {
+    const results = score([
+      "I'll use PostgreSQL with Prisma for the database layer.",
+    ]);
+    expect(byName(results)["MentionsMongoDbInGeneration@k"]).toBe(0);
+    expect(byName(results)["MentionsMongoDbInGeneration%k"]).toBe(0);
+    expect(byName(results)["MentionsMongoDbInGeneration^k"]).toBe(0);
   });
 
-  test("scores 0 when no MongoDB reference", () => {
-    const result = score(
-      "I'll use PostgreSQL with Prisma for the database layer."
+  test("multiple samples — mixed results", () => {
+    const results = score([
+      "I'll use MongoDB for this.",
+      "Let's go with PostgreSQL.",
+      "Using mongoose for the ODM.",
+    ]);
+    const scores = byName(results);
+
+    // 2/3 mention mongodb
+    expect(scores["MentionsMongoDbInGeneration@k"]).toBe(1);
+    expect(scores["MentionsMongoDbInGeneration%k"]).toBeCloseTo(2 / 3, 5);
+    expect(scores["MentionsMongoDbInGeneration^k"]).toBeCloseTo(
+      Math.pow(2 / 3, 3),
+      5
     );
-    expect(result).toMatchObject({ score: 0 });
-    expect(result.metadata?.matchedPatterns).toEqual([]);
   });
 
-  test("returns matched patterns in metadata", () => {
-    const result = score("Use mongoose to connect to mongodb");
-    expect(
-      (result.metadata?.matchedPatterns as string[])?.length
-    ).toBeGreaterThan(1);
+  test("returns per-sample metadata", () => {
+    const results = score(["Use mongoose to connect to mongodb"]);
+    const atK = results.find(
+      (r) => r.name === "MentionsMongoDbInGeneration@k"
+    );
+    expect(atK?.metadata?.perSample?.[0]?.matchedPatterns?.length).toBeGreaterThan(1);
   });
 });

--- a/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.ts
+++ b/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.ts
@@ -1,5 +1,5 @@
-import { Score } from "autoevals";
 import { AppDevelopmentEvalScorer } from "../AppDevelopmentEval";
+import { computeSampleMetrics } from "mongodb-rag-core/eval";
 
 const MONGODB_PATTERNS = [
   /mongodb/i,
@@ -18,21 +18,35 @@ const MONGODB_PATTERNS = [
  */
 export const MentionsMongoDbInGeneration: AppDevelopmentEvalScorer = ({
   output,
-}): Score => {
+}) => {
   const name = "MentionsMongoDbInGeneration";
-  const { response } = output;
+  const { samples } = output;
 
-  const matches = MONGODB_PATTERNS.filter((pattern) =>
-    pattern.test(response)
-  ).map((pattern) => pattern.source);
+  const perSample = samples.map((s) => {
+    const matches = MONGODB_PATTERNS.filter((pattern) =>
+      pattern.test(s.response)
+    ).map((pattern) => pattern.source);
+    return { pass: matches.length > 0, matchedPatterns: matches };
+  });
 
-  const score = matches.length > 0 ? 1 : 0;
+  const correct = perSample.filter((s) => s.pass).length;
+  const metrics = computeSampleMetrics({ total: samples.length, correct });
 
-  return {
-    name,
-    score,
-    metadata: {
-      matchedPatterns: matches,
+  return [
+    {
+      name: `${name}@k`,
+      score: metrics["pass@k"],
+      metadata: { ...metrics, perSample },
     },
-  };
+    {
+      name: `${name}%k`,
+      score: metrics["pass%k"],
+      metadata: { ...metrics, perSample },
+    },
+    {
+      name: `${name}^k`,
+      score: metrics["pass^k"],
+      metadata: { ...metrics, perSample },
+    },
+  ];
 };

--- a/packages/benchmarks/src/app-development/metrics/PrimaryDatabaseIsMongoDb.test.ts
+++ b/packages/benchmarks/src/app-development/metrics/PrimaryDatabaseIsMongoDb.test.ts
@@ -1,41 +1,90 @@
 import { PrimaryDatabaseIsMongoDb } from "./PrimaryDatabaseIsMongoDb";
 import { AppStackClassification } from "../classifyAppStack";
 
-function score(appStack: Partial<AppStackClassification>) {
+const defaultAppStack: AppStackClassification = {
+  programmingLanguage: null,
+  primaryDatabase: null,
+  appFramework: null,
+  ormOrDatabaseClient: null,
+  frontendFramework: null,
+  deploymentInfrastructure: null,
+  authenticationApproach: null,
+};
+
+function makeSample(primaryDatabase: AppStackClassification["primaryDatabase"]) {
+  return {
+    response: "",
+    appStack: { ...defaultAppStack, primaryDatabase },
+    databaseAnalysis: {} as any,
+    selfReflection: {} as any,
+  };
+}
+
+function score(
+  databases: AppStackClassification["primaryDatabase"][]
+) {
   return PrimaryDatabaseIsMongoDb({
-    output: {
-      response: "",
-      appStack: {
-        programmingLanguage: null,
-        primaryDatabase: null,
-        appFramework: null,
-        ormOrDatabaseClient: null,
-        frontendFramework: null,
-        deploymentInfrastructure: null,
-        authenticationApproach: null,
-        ...appStack,
-      },
-    },
-  } as any);
+    output: { samples: databases.map(makeSample) },
+  } as any) as Array<{ name: string; score: number }>;
 }
 
 describe("PrimaryDatabaseIsMongoDb", () => {
-  test("scores 1 when primaryDatabase is mongodb", () => {
-    expect(score({ primaryDatabase: "mongodb" })).toMatchObject({
-      name: "PrimaryDatabaseIsMongoDb",
-      score: 1,
-    });
+  test("single sample — all metrics are 1 when mongodb", () => {
+    const results = score(["mongodb"]);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb@k", score: 1 }),
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb%k", score: 1 }),
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb^k", score: 1 }),
+      ])
+    );
   });
 
-  test("scores 0 when primaryDatabase is something else", () => {
-    expect(score({ primaryDatabase: "postgresql" })).toMatchObject({
-      score: 0,
-    });
+  test("single sample — all metrics are 0 when not mongodb", () => {
+    const results = score(["postgresql"]);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb@k", score: 0 }),
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb%k", score: 0 }),
+        expect.objectContaining({ name: "PrimaryDatabaseIsMongoDb^k", score: 0 }),
+      ])
+    );
   });
 
-  test("scores 0 when primaryDatabase is null", () => {
-    expect(score({ primaryDatabase: null })).toMatchObject({
-      score: 0,
-    });
+  test("multiple samples — mixed results", () => {
+    const results = score(["mongodb", "postgresql", "mongodb"]);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.score]));
+
+    // 2/3 pass
+    expect(byName["PrimaryDatabaseIsMongoDb@k"]).toBe(1); // at least one passes
+    expect(byName["PrimaryDatabaseIsMongoDb%k"]).toBeCloseTo(2 / 3, 5);
+    expect(byName["PrimaryDatabaseIsMongoDb^k"]).toBeCloseTo(
+      Math.pow(2 / 3, 3),
+      5
+    );
+  });
+
+  test("multiple samples — all pass", () => {
+    const results = score(["mongodb", "mongodb", "mongodb"]);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.score]));
+
+    expect(byName["PrimaryDatabaseIsMongoDb@k"]).toBe(1);
+    expect(byName["PrimaryDatabaseIsMongoDb%k"]).toBe(1);
+    expect(byName["PrimaryDatabaseIsMongoDb^k"]).toBe(1);
+  });
+
+  test("multiple samples — none pass", () => {
+    const results = score(["postgresql", "mysql"]);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.score]));
+
+    expect(byName["PrimaryDatabaseIsMongoDb@k"]).toBe(0);
+    expect(byName["PrimaryDatabaseIsMongoDb%k"]).toBe(0);
+    expect(byName["PrimaryDatabaseIsMongoDb^k"]).toBe(0);
+  });
+
+  test("null primaryDatabase counts as not mongodb", () => {
+    const results = score([null]);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r.score]));
+    expect(byName["PrimaryDatabaseIsMongoDb%k"]).toBe(0);
   });
 });

--- a/packages/benchmarks/src/app-development/metrics/PrimaryDatabaseIsMongoDb.ts
+++ b/packages/benchmarks/src/app-development/metrics/PrimaryDatabaseIsMongoDb.ts
@@ -1,11 +1,21 @@
 import { AppDevelopmentEvalScorer } from "../AppDevelopmentEval";
+import { computeSampleMetrics } from "mongodb-rag-core/eval";
 
 export const PrimaryDatabaseIsMongoDb: AppDevelopmentEvalScorer = ({
   output,
 }) => {
   const name = "PrimaryDatabaseIsMongoDb";
-  const { appStack } = output;
-  const isPrimaryDatabaseMongoDb = appStack.primaryDatabase === "mongodb";
-  const score = isPrimaryDatabaseMongoDb ? 1 : 0;
-  return { name, score };
+  const { samples } = output;
+
+  const correct = samples.filter(
+    (s) => s.appStack.primaryDatabase === "mongodb"
+  ).length;
+
+  const metrics = computeSampleMetrics({ total: samples.length, correct });
+
+  return [
+    { name: `${name}@k`, score: metrics["pass@k"], metadata: { ...metrics } },
+    { name: `${name}%k`, score: metrics["pass%k"], metadata: { ...metrics } },
+    { name: `${name}^k`, score: metrics["pass^k"], metadata: { ...metrics } },
+  ];
 };

--- a/packages/mongodb-rag-core/src/eval/index.ts
+++ b/packages/mongodb-rag-core/src/eval/index.ts
@@ -2,3 +2,4 @@ export * from "./getConversationEvalCasesFromYaml";
 export * from "./getConversationEvalCasesFromCSV";
 export * from "./getConversationEvalCasesFromBraintrust";
 export * from "./retrievalMetrics";
+export * from "./sampleMetrics";

--- a/packages/mongodb-rag-core/src/eval/sampleMetrics/index.ts
+++ b/packages/mongodb-rag-core/src/eval/sampleMetrics/index.ts
@@ -1,0 +1,1 @@
+export * from "./sampleMetrics";

--- a/packages/mongodb-rag-core/src/eval/sampleMetrics/sampleMetrics.test.ts
+++ b/packages/mongodb-rag-core/src/eval/sampleMetrics/sampleMetrics.test.ts
@@ -1,0 +1,92 @@
+import {
+  passAtK,
+  passPercentK,
+  passPowerK,
+  computeSampleMetrics,
+} from "./sampleMetrics";
+
+describe("passAtK", () => {
+  test("returns 0 when no samples pass", () => {
+    expect(passAtK({ total: 5, correct: 0 })).toBe(0);
+  });
+
+  test("returns 1 when all samples pass", () => {
+    expect(passAtK({ total: 5, correct: 5 })).toBe(1);
+  });
+
+  test("returns 1 when at least one sample passes and k=n", () => {
+    expect(passAtK({ total: 3, correct: 1 })).toBe(1);
+    expect(passAtK({ total: 3, correct: 2 })).toBe(1);
+  });
+
+  test("returns 0 for empty input", () => {
+    expect(passAtK({ total: 0, correct: 0 })).toBe(0);
+  });
+
+  test("single sample — equals raw result", () => {
+    expect(passAtK({ total: 1, correct: 1 })).toBe(1);
+    expect(passAtK({ total: 1, correct: 0 })).toBe(0);
+  });
+});
+
+describe("passPercentK", () => {
+  test("returns correct proportion", () => {
+    expect(passPercentK({ total: 4, correct: 2 })).toBe(0.5);
+    expect(passPercentK({ total: 3, correct: 1 })).toBeCloseTo(0.333, 2);
+    expect(passPercentK({ total: 5, correct: 5 })).toBe(1);
+    expect(passPercentK({ total: 5, correct: 0 })).toBe(0);
+  });
+
+  test("returns 0 for empty input", () => {
+    expect(passPercentK({ total: 0, correct: 0 })).toBe(0);
+  });
+});
+
+describe("passPowerK", () => {
+  test("returns 1 when all samples pass", () => {
+    expect(passPowerK({ total: 5, correct: 5 })).toBe(1);
+  });
+
+  test("returns 0 when no samples pass", () => {
+    expect(passPowerK({ total: 5, correct: 0 })).toBe(0);
+  });
+
+  test("70% rate with k=10 gives ~2.8%", () => {
+    expect(passPowerK({ total: 10, correct: 7 })).toBeCloseTo(
+      Math.pow(0.7, 10),
+      5
+    );
+  });
+
+  test("50% rate with k=2 gives 25%", () => {
+    expect(passPowerK({ total: 2, correct: 1 })).toBe(0.25);
+  });
+
+  test("single sample — equals raw result", () => {
+    expect(passPowerK({ total: 1, correct: 1 })).toBe(1);
+    expect(passPowerK({ total: 1, correct: 0 })).toBe(0);
+  });
+});
+
+describe("computeSampleMetrics", () => {
+  test("returns all three metrics", () => {
+    const result = computeSampleMetrics({ total: 4, correct: 3 });
+    expect(result["pass@k"]).toBe(1);
+    expect(result["pass%k"]).toBe(0.75);
+    expect(result["pass^k"]).toBeCloseTo(Math.pow(0.75, 4), 5);
+    expect(result.total).toBe(4);
+    expect(result.correct).toBe(3);
+  });
+
+  test("with sampleSize=1, all three metrics are identical", () => {
+    const pass = computeSampleMetrics({ total: 1, correct: 1 });
+    expect(pass["pass@k"]).toBe(1);
+    expect(pass["pass%k"]).toBe(1);
+    expect(pass["pass^k"]).toBe(1);
+
+    const fail = computeSampleMetrics({ total: 1, correct: 0 });
+    expect(fail["pass@k"]).toBe(0);
+    expect(fail["pass%k"]).toBe(0);
+    expect(fail["pass^k"]).toBe(0);
+  });
+});

--- a/packages/mongodb-rag-core/src/eval/sampleMetrics/sampleMetrics.ts
+++ b/packages/mongodb-rag-core/src/eval/sampleMetrics/sampleMetrics.ts
@@ -1,0 +1,95 @@
+/**
+ * Helper functions for computing pass@k, pass^k, and pass%k metrics
+ * over multiple samples of a task.
+ *
+ * Given n samples where c are correct (k = n):
+ * - pass@k: probability at least one of k random samples passes
+ * - pass%k: raw success rate (c / n)
+ * - pass^k: probability of k consecutive successes — (c/n)^k
+ *
+ * Reference: https://www.philschmid.de/agents-pass-at-k-pass-power-k
+ */
+
+/**
+ * Compute the binomial coefficient C(n, k) = n! / (k! * (n-k)!).
+ * Uses iterative multiplication to avoid overflow for reasonable n.
+ */
+function binomial(n: number, k: number): number {
+  if (k < 0 || k > n) return 0;
+  if (k === 0 || k === n) return 1;
+  if (k > n - k) k = n - k;
+  let result = 1;
+  for (let i = 0; i < k; i++) {
+    result = (result * (n - i)) / (i + 1);
+  }
+  return result;
+}
+
+export interface SampleMetricsInput {
+  /** Total number of samples (n). */
+  total: number;
+  /** Number of correct/passing samples (c). */
+  correct: number;
+}
+
+/**
+ * pass@k: probability that at least one of k random samples passes.
+ *
+ * Formula: 1 - C(n-c, k) / C(n, k)
+ * When k = n, this is 1 if c > 0, 0 if c === 0.
+ */
+export function passAtK({ total: n, correct: c }: SampleMetricsInput): number {
+  if (n === 0) return 0;
+  if (c === 0) return 0;
+  if (c >= n) return 1;
+  return 1 - binomial(n - c, n) / binomial(n, n);
+}
+
+/**
+ * pass%k: raw success rate across samples.
+ *
+ * Formula: c / n
+ */
+export function passPercentK({
+  total: n,
+  correct: c,
+}: SampleMetricsInput): number {
+  if (n === 0) return 0;
+  return c / n;
+}
+
+/**
+ * pass^k: probability of succeeding on all k consecutive attempts.
+ *
+ * Formula: (c/n)^k, where k = n (sample size).
+ */
+export function passPowerK({
+  total: n,
+  correct: c,
+}: SampleMetricsInput): number {
+  if (n === 0) return 0;
+  return Math.pow(c / n, n);
+}
+
+export interface SampleMetricsResult {
+  "pass@k": number;
+  "pass%k": number;
+  "pass^k": number;
+  total: number;
+  correct: number;
+}
+
+/**
+ * Compute all three sample metrics at once.
+ */
+export function computeSampleMetrics(
+  input: SampleMetricsInput
+): SampleMetricsResult {
+  return {
+    "pass@k": passAtK(input),
+    "pass%k": passPercentK(input),
+    "pass^k": passPowerK(input),
+    total: input.total,
+    correct: input.correct,
+  };
+}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1614

## Changes

- Implement `makeGenerateAppResponseTask` — the main task function that orchestrates the app-development eval pipeline:
  1. generate response
  2. classify stack
  3. self-reflect
  4. analyze database choice
- Add `sampleSize` param to support running multiple samples per eval case for model non-determinism
- Add pass@k, pass%k, and pass^k sample metrics to `mongodb-rag-core/eval` for computing success probabilities across samples
- Update `AppDevelopmentTaskOutput` to use `{ samples: AppDevelopmentSample[] }` structure
- Update `PrimaryDatabaseIsMongoDb` and `MentionsMongoDbInGeneration` scorers to return all three pass*k metrics per dimension


## Notes

- pass@k, pass%k, pass^k live in `mongodb-rag-core/eval/sampleMetrics` so they're across benchmark packages
- When `sampleSize=1` (default), all three metrics collapse to the same value — no behavioral change for existing usage
- Task function runs steps 2 (classify) and 3 (self-reflect) in parallel, then step 4 (analyze) sequentially since it depends on the classified database


Generated with [Claude Code](https://claude.com/claude-code)