### PR TITLE
EAI-1977: pass through trialCount

### DIFF
--- a/packages/benchmarks/src/cli/benchmarkCli.test.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.test.ts
@@ -224,6 +224,35 @@ describe("makeBenchmarkCli", () => {
       ]);
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
+
+    it("should validate trialCount is a positive integer", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--dataset",
+        "dataset1",
+        "--trialCount",
+        "0",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+
+      processExitSpy.mockClear();
+
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--dataset",
+        "dataset1",
+        "--trialCount",
+        "1.5",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
     it("should validate sampleSize is a positive integer", async () => {
       const cli = makeBenchmarkCli(mockConfig);
       cli.parse([
@@ -292,7 +321,32 @@ describe("makeBenchmarkCli", () => {
         models: mockConfig.models,
         datasets: ["dataset1"],
         modelConcurrency: 2,
+        sampleSize: undefined,
+        sampleType: undefined,
+        taskConcurrency: undefined,
+        trialCount: 1,
       });
+    });
+
+    it("should pass trialCount to runBenchmark", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      await cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--dataset",
+        "dataset1",
+        "--trialCount",
+        "3",
+      ]);
+
+      expect(mockRunBenchmark).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          trialCount: 3,
+        })
+      );
     });
 
     it("should use default values when optional arguments not provided", async () => {
@@ -312,6 +366,10 @@ describe("makeBenchmarkCli", () => {
         models: mockConfig.models, // All models
         datasets: ["dataset1"],
         modelConcurrency: 2,
+        sampleSize: undefined,
+        sampleType: undefined,
+        taskConcurrency: undefined,
+        trialCount: 1,
       });
     });
 
@@ -342,6 +400,7 @@ describe("makeBenchmarkCli", () => {
         taskConcurrency: 3,
         sampleType: undefined,
         sampleSize: undefined,
+        trialCount: 1,
       });
     });
 

--- a/packages/benchmarks/src/cli/benchmarkCli.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.ts
@@ -55,6 +55,12 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               "Number of models to run experiments on at once. Default is 2.",
             default: 2,
           })
+          .option("trialCount", {
+            type: "number",
+            describe:
+              "Number of times to run each input through the task. Default is 1.",
+            default: 1,
+          })
           .strict()
           .check((argv) => {
             const errors: string[] = [];
@@ -128,6 +134,13 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               errors.push("sampleSize must be a positive integer");
             }
 
+            if (
+              !Number.isInteger(argv.trialCount) ||
+              argv.trialCount < 1
+            ) {
+              errors.push("trialCount must be a positive integer");
+            }
+
             if (errors.length > 0) {
               throw new Error(errors.join(", "));
             }
@@ -155,6 +168,7 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
             modelConcurrency: argv.modelConcurrency,
             sampleSize: argv.sampleSize,
             sampleType: argv.sampleType,
+            trialCount: argv.trialCount,
           };
           await runBenchmark(config, args);
         } catch (error) {

--- a/packages/benchmarks/src/cli/runBenchmark.test.ts
+++ b/packages/benchmarks/src/cli/runBenchmark.test.ts
@@ -318,7 +318,19 @@ describe("runBenchmark", () => {
         },
         task: "mock-task-result",
         scores: [mockScorerFunc],
+        trialCount: undefined,
       });
+    });
+
+    it("should pass trialCount to Eval when provided", async () => {
+      await runBenchmark(mockConfig, { ...mockArgs, trialCount: 3 });
+
+      expect(mockEval).toHaveBeenCalledWith(
+        "test-project",
+        expect.objectContaining({
+          trialCount: 3,
+        })
+      );
     });
 
     it("should use taskConcurrency when provided", async () => {

--- a/packages/benchmarks/src/cli/runBenchmark.ts
+++ b/packages/benchmarks/src/cli/runBenchmark.ts
@@ -14,6 +14,7 @@ export interface RunBenchmarkArgs {
   modelConcurrency: number;
   sampleSize?: number;
   sampleType?: "firstN" | "random";
+  trialCount?: number;
 }
 
 export async function runBenchmark(
@@ -27,6 +28,7 @@ export async function runBenchmark(
     modelConcurrency,
     sampleSize,
     sampleType,
+    trialCount,
   }: RunBenchmarkArgs
 ) {
   const benchmarkConfig = config.benchmarks[type];
@@ -116,6 +118,7 @@ export async function runBenchmark(
             },
             task: await taskToRun.taskFunc(config.modelProvider, model),
             scores,
+            trialCount,
           });
 
           console.log(`✓ Completed experiment: ${experimentName}`);


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1977

## Changes

- Pass `trialCount` param from our CLI through to Braintrust `Eval()`
-

## Notes

-
