### PR TITLE
EAI-1974: Add coding-agent app-development utils `extractFilesFromSandbox` & `extractDbLibrariesUsed`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7881,6 +7881,42 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vercel/sandbox": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-1.10.2.tgz",
+      "integrity": "sha512-rWhYfIyW0Va0gFxtz434LhVirV+eQs+AK0QQWtsOPw2oTvOSA4iogQqemRqvRPPbqI8nfZOz6kbCsytVa20gdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0",
+        "@workflow/serde": "4.1.0-beta.2",
+        "async-retry": "1.3.3",
+        "jsonlines": "0.1.1",
+        "ms": "2.1.3",
+        "picocolors": "^1.1.1",
+        "tar-stream": "3.1.7",
+        "undici": "^7.16.0",
+        "xdg-app-paths": "5.1.0",
+        "zod": "3.24.4"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@vitest/eslint-plugin": {
       "version": "1.3.6",
       "license": "MIT",
@@ -8052,6 +8088,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "license": "Apache-2.0"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -8541,7 +8583,6 @@
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
@@ -8639,7 +8680,6 @@
     },
     "node_modules/b4a": {
       "version": "1.6.7",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
@@ -8788,7 +8828,6 @@
     },
     "node_modules/bare-events": {
       "version": "2.6.1",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
@@ -13220,7 +13259,6 @@
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -16899,6 +16937,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
+      "license": "MIT"
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -21357,6 +21401,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "dev": true,
@@ -21984,7 +22037,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -25443,7 +25495,6 @@
     },
     "node_modules/streamx": {
       "version": "2.22.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -25851,7 +25902,6 @@
     },
     "node_modules/tar-stream": {
       "version": "3.1.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -25970,7 +26020,6 @@
     },
     "node_modules/text-decoder": {
       "version": "1.2.3",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -26617,10 +26666,10 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.15.0",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -28024,6 +28073,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xdg-app-paths": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
+      "integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "xdg-portable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",
       "dev": true,
@@ -28033,6 +28094,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xml-name-validator": {
@@ -28228,6 +28301,7 @@
         "@ai-sdk/openai": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.17.2",
         "@supercharge/promise-pool": "^3.2.0",
+        "@vercel/sandbox": "^1.10.2",
         "ai": "^6.0.0",
         "autoevals": "^0.0.129",
         "csv-writer": "^1.6.0",

--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -49,6 +49,7 @@
     "@ai-sdk/openai": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "@supercharge/promise-pool": "^3.2.0",
+    "@vercel/sandbox": "^1.10.2",
     "ai": "^6.0.0",
     "autoevals": "^0.0.129",
     "csv-writer": "^1.6.0",

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
@@ -1,0 +1,153 @@
+import { extractDbLibrariesUsed } from "./extractDbLibrariesUsed";
+import { Files } from "../CodingAgentAppDevelopmentEval";
+
+function packageJson(deps: {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}): string {
+  return JSON.stringify({ name: "test-app", version: "1.0.0", ...deps });
+}
+
+describe("extractDbLibrariesUsed", () => {
+  test("detects the mongodb driver in dependencies", () => {
+    const files: Files = {
+      "package.json": packageJson({ dependencies: { mongodb: "^6.0.0" } }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "mongodb",
+      database: "mongodb",
+      packageJsonPath: "package.json",
+      field: "dependencies",
+    });
+  });
+
+  test("detects mongoose ODM as mongodb", () => {
+    const files: Files = {
+      "package.json": packageJson({ dependencies: { mongoose: "^8.0.0" } }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result.map((r) => r.library)).toContain("mongoose");
+    expect(result.find((r) => r.library === "mongoose")?.database).toBe(
+      "mongodb"
+    );
+  });
+
+  test("detects the bson library as mongodb (mirrors MongoDbInPackageJsonScorer)", () => {
+    const files: Files = {
+      "package.json": packageJson({ dependencies: { bson: "^6.0.0" } }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result.find((r) => r.library === "bson")?.database).toBe("mongodb");
+  });
+
+  test("maps competitor drivers to their database (pg, mysql2, redis)", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: { pg: "^8.0.0", mysql2: "^3.0.0", redis: "^4.0.0" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    const byLib = Object.fromEntries(
+      result.map((r) => [r.library, r.database])
+    );
+    expect(byLib["pg"]).toBe("postgresql");
+    expect(byLib["mysql2"]).toBe("mysql");
+    expect(byLib["redis"]).toBe("redis");
+  });
+
+  test("detects scoped packages via org prefix (@supabase, @neondatabase)", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: {
+          "@supabase/supabase-js": "^2.0.0",
+          "@neondatabase/serverless": "^0.9.0",
+        },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    const byLib = Object.fromEntries(
+      result.map((r) => [r.library, r.database])
+    );
+    expect(byLib["@supabase/supabase-js"]).toBe("supabase");
+    expect(byLib["@neondatabase/serverless"]).toBe("neon");
+  });
+
+  test("maps multi-database ORMs to a null database", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: { "@prisma/client": "^5.0.0", "drizzle-orm": "^0.30.0" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    const byLib = Object.fromEntries(
+      result.map((r) => [r.library, r.database])
+    );
+    expect(byLib).toHaveProperty("@prisma/client");
+    expect(byLib["@prisma/client"]).toBeNull();
+    expect(byLib["drizzle-orm"]).toBeNull();
+  });
+
+  test("detects libraries listed in devDependencies", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        devDependencies: { "better-sqlite3": "^11.0.0" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "better-sqlite3",
+      database: "sqlite",
+      packageJsonPath: "package.json",
+      field: "devDependencies",
+    });
+  });
+
+  test("ignores non-database dependencies", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: { express: "^4.0.0", react: "^18.0.0", lodash: "^4.0.0" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toEqual([]);
+  });
+
+  test("scans package.json files in nested directories", () => {
+    const files: Files = {
+      "backend/package.json": packageJson({
+        dependencies: { mongodb: "^6.0.0" },
+      }),
+      "frontend/package.json": packageJson({
+        dependencies: { react: "^18.0.0" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toHaveLength(1);
+    expect(result[0].packageJsonPath).toBe("backend/package.json");
+    expect(result[0].library).toBe("mongodb");
+  });
+
+  test("ignores files that are not package.json (e.g. package-lock.json)", () => {
+    const files: Files = {
+      "package-lock.json": packageJson({
+        dependencies: { mongodb: "^6.0.0" },
+      }),
+      "src/mongodb.ts": "import { MongoClient } from 'mongodb';",
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toEqual([]);
+  });
+
+  test("skips package.json files with invalid JSON", () => {
+    const files: Files = {
+      "package.json": "{ not valid json ",
+    };
+    expect(() => extractDbLibrariesUsed({ files })).not.toThrow();
+    expect(extractDbLibrariesUsed({ files })).toEqual([]);
+  });
+
+  test("returns an empty array when no files are provided", () => {
+    expect(extractDbLibrariesUsed({ files: {} })).toEqual([]);
+  });
+});

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
@@ -1,0 +1,211 @@
+import { Files } from "../CodingAgentAppDevelopmentEval";
+import { PrimaryDatabase } from "../../app-development/classifyAppStack";
+
+/**
+ * A database-related npm library detected in a generated `package.json`.
+ */
+export type DetectedDbLibrary = {
+  /** The npm package name exactly as it appears in the dependency list. */
+  library: string;
+  /**
+   * The database technology the library is associated with, drawn from the
+   * `primaryDatabases` enum in {@link classifyAppStack}. `null` for
+   * multi-database ORMs/query builders (e.g. Prisma, Drizzle) where the
+   * concrete database can't be inferred from the library alone.
+   */
+  database: PrimaryDatabase | null;
+  /** Path of the `package.json` the library was found in. */
+  packageJsonPath: string;
+  /** Which dependency field the library was listed under. */
+  field: "dependencies" | "devDependencies";
+};
+
+/**
+ * Hardcoded map of npm package names to the database technology they indicate.
+ *
+ * Entries ending in `/` are treated as scope prefixes — they match any package
+ * whose name starts with that prefix (e.g. `@supabase/` matches
+ * `@supabase/supabase-js`). All other entries match the package name exactly.
+ *
+ * The MongoDB entries mirror the patterns in `MongoDbInImportsScorer`. The
+ * database values come from the `primaryDatabases` enum in `classifyAppStack`.
+ * Multi-database ORMs and query builders map to `null` because the underlying
+ * database can't be determined from the library name alone.
+ */
+export const DB_LIBRARIES: Record<string, PrimaryDatabase | null> = {
+  // MongoDB
+  mongodb: "mongodb",
+  mongoose: "mongodb",
+  bson: "mongodb",
+  "mongodb-memory-server": "mongodb",
+  "@mongodb-js/": "mongodb",
+
+  // PostgreSQL (and Postgres-wire-compatible databases)
+  pg: "postgresql",
+  "pg-promise": "postgresql",
+  postgres: "postgresql",
+  "@vercel/postgres": "postgresql",
+  slonik: "postgresql",
+  "@neondatabase/": "neon",
+  "@planetscale/database": "planetscale",
+  cockroachdb: "cockroachdb",
+
+  // MySQL / MariaDB
+  mysql: "mysql",
+  mysql2: "mysql",
+  mariadb: "mariadb",
+
+  // SQLite / libSQL (Turso)
+  sqlite3: "sqlite",
+  "better-sqlite3": "sqlite",
+  "node:sqlite": "sqlite",
+  "@libsql/client": "turso",
+  libsql: "turso",
+
+  // SQL Server
+  mssql: "mssql",
+  tedious: "mssql",
+
+  // Oracle
+  oracledb: "oracle",
+
+  // BaaS / managed
+  "@supabase/": "supabase",
+  firebase: "firestore",
+  "firebase-admin": "firestore",
+  "@firebase/": "firestore",
+  "@google-cloud/firestore": "firestore",
+  appwrite: "appwrite",
+  "node-appwrite": "appwrite",
+  pocketbase: "pocketbase",
+  convex: "convex",
+  airtable: "airtable",
+  fauna: "fauna",
+  faunadb: "fauna",
+
+  // AWS DynamoDB
+  "@aws-sdk/client-dynamodb": "dynamodb",
+  "@aws-sdk/lib-dynamodb": "dynamodb",
+  "dynamodb-toolbox": "dynamodb",
+  "@azure/cosmos": "cosmosdb",
+
+  // Key-value / cache
+  redis: "redis",
+  ioredis: "redis",
+  "@redis/client": "redis",
+  iovalkey: "valkey",
+  "@valkey/": "valkey",
+  memcached: "memcached",
+  memjs: "memcached",
+
+  // Search / analytics
+  "@elastic/elasticsearch": "elasticsearch",
+  "@opensearch-project/opensearch": "opensearch",
+  "@clickhouse/client": "clickhouse",
+  "@influxdata/influxdb-client": "influxdb",
+  duckdb: "duckdb",
+  "@duckdb/node-api": "duckdb",
+
+  // Document / other NoSQL
+  nano: "couchdb",
+  couchbase: "couchbase",
+  surrealdb: "surrealdb",
+  "surrealdb.js": "surrealdb",
+
+  // Graph
+  "neo4j-driver": "neo4j",
+  arangojs: "arangodb",
+  "dgraph-js": "dgraph",
+
+  // Vector
+  "@pinecone-database/pinecone": "pinecone",
+  "weaviate-ts-client": "weaviate",
+  "weaviate-client": "weaviate",
+  "@qdrant/js-client-rest": "qdrant",
+  chromadb: "chroma",
+  "@zilliz/milvus2-sdk-node": "milvus",
+
+  // Cloudflare
+  "@cloudflare/d1": "cloudflare-d1",
+
+  // Multi-database ORMs / query builders — concrete DB is undetermined.
+  prisma: null,
+  "@prisma/client": null,
+  typeorm: null,
+  "drizzle-orm": null,
+  sequelize: null,
+  knex: null,
+  objection: null,
+  "@mikro-orm/core": null,
+  bookshelf: null,
+  kysely: null,
+};
+
+const SCOPE_PREFIXES = Object.keys(DB_LIBRARIES).filter((name) =>
+  name.endsWith("/")
+);
+
+function isPackageJson(path: string): boolean {
+  return path === "package.json" || path.endsWith("/package.json");
+}
+
+function lookupDatabase(
+  packageName: string
+): { matched: true; database: PrimaryDatabase | null } | { matched: false } {
+  if (Object.prototype.hasOwnProperty.call(DB_LIBRARIES, packageName)) {
+    return { matched: true, database: DB_LIBRARIES[packageName] };
+  }
+  const prefix = SCOPE_PREFIXES.find((p) => packageName.startsWith(p));
+  if (prefix) {
+    return { matched: true, database: DB_LIBRARIES[prefix] };
+  }
+  return { matched: false };
+}
+
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies"] as const;
+
+/**
+ * Inspect every `package.json` in the generated files and report which
+ * database libraries appear in their `dependencies` / `devDependencies`.
+ *
+ * Only checks `package.json` files, so this is scoped to the Node/JS
+ * ecosystem. Invalid JSON is skipped silently.
+ */
+export function extractDbLibrariesUsed({
+  files,
+}: {
+  files: Files;
+}): DetectedDbLibrary[] {
+  const detected: DetectedDbLibrary[] = [];
+
+  for (const [path, content] of Object.entries(files)) {
+    if (!isPackageJson(path)) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+
+    for (const field of DEPENDENCY_FIELDS) {
+      const deps = (parsed as Record<string, unknown>)[field];
+      if (typeof deps !== "object" || deps === null) continue;
+
+      for (const packageName of Object.keys(deps)) {
+        const result = lookupDatabase(packageName);
+        if (result.matched) {
+          detected.push({
+            library: packageName,
+            database: result.database,
+            packageJsonPath: path,
+            field,
+          });
+        }
+      }
+    }
+  }
+
+  return detected;
+}

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractFilesFromSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractFilesFromSandbox.test.ts
@@ -1,0 +1,129 @@
+import type { Sandbox } from "@vercel/sandbox";
+import { extractFilesFromSandbox } from "./extractFilesFromSandbox";
+
+/**
+ * Builds an in-memory fake of the bits of the `@vercel/sandbox` filesystem
+ * that `extractFilesFromSandbox` touches (`readdir`, `stat`, `readFile`),
+ * driven by a flat map of absolute file path -> content.
+ */
+function makeFakeSandbox(
+  fileTree: Record<string, string | { content: string; size: number }>
+): Sandbox {
+  const fileMap = new Map<string, { content: string; size: number }>();
+  for (const [path, value] of Object.entries(fileTree)) {
+    const content = typeof value === "string" ? value : value.content;
+    const size =
+      typeof value === "string" ? Buffer.byteLength(content) : value.size;
+    fileMap.set(path, { content, size });
+  }
+
+  const fs = {
+    async readdir(dir: string) {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      const isDirByName = new Map<string, boolean>();
+      for (const path of fileMap.keys()) {
+        if (!path.startsWith(prefix)) continue;
+        const rest = path.slice(prefix.length);
+        const [firstSegment] = rest.split("/");
+        const isDir = rest.includes("/");
+        if (!isDirByName.has(firstSegment) || isDir) {
+          isDirByName.set(firstSegment, isDir);
+        }
+      }
+      if (isDirByName.size === 0) {
+        throw new Error(`ENOENT: no such directory ${dir}`);
+      }
+      return [...isDirByName.entries()].map(([name, isDir]) => ({
+        name,
+        isDirectory: () => isDir,
+      }));
+    },
+    async stat(path: string) {
+      const file = fileMap.get(path);
+      if (!file) throw new Error(`ENOENT: ${path}`);
+      return { size: file.size, isDirectory: () => false };
+    },
+    async readFile(path: string) {
+      const file = fileMap.get(path);
+      if (!file) throw new Error(`ENOENT: ${path}`);
+      return file.content;
+    },
+  };
+
+  return { fs } as unknown as Sandbox;
+}
+
+describe("extractFilesFromSandbox", () => {
+  test("collects files recursively, keyed by path relative to rootDir", async () => {
+    const sandbox = makeFakeSandbox({
+      "/app/package.json": '{"name":"demo"}',
+      "/app/src/index.ts": "console.log('hi')",
+      "/app/src/db/client.ts": "export const client = {}",
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox, rootDir: "/app" });
+
+    expect(files).toEqual({
+      "package.json": '{"name":"demo"}',
+      "src/index.ts": "console.log('hi')",
+      "src/db/client.ts": "export const client = {}",
+    });
+  });
+
+  test("ignores dependency / build directories like node_modules and .git", async () => {
+    const sandbox = makeFakeSandbox({
+      "/app/index.js": "const x = 1",
+      "/app/node_modules/left-pad/index.js": "module.exports = () => {}",
+      "/app/.git/config": "[core]",
+      "/app/dist/index.js": "compiled",
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox, rootDir: "/app" });
+
+    expect(Object.keys(files)).toEqual(["index.js"]);
+  });
+
+  test("skips dotfiles", async () => {
+    const sandbox = makeFakeSandbox({
+      "/app/index.js": "const x = 1",
+      "/app/.env": "SECRET=shh",
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox, rootDir: "/app" });
+
+    expect(Object.keys(files)).toContain("index.js");
+    expect(Object.keys(files)).not.toContain(".env");
+  });
+
+  test("skips files larger than the max file size", async () => {
+    const sandbox = makeFakeSandbox({
+      "/app/small.txt": "ok",
+      "/app/huge.bin": { content: "x", size: 200_000 },
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox, rootDir: "/app" });
+
+    expect(Object.keys(files)).toContain("small.txt");
+    expect(Object.keys(files)).not.toContain("huge.bin");
+  });
+
+  test("returns an empty object when the root directory cannot be read", async () => {
+    const sandbox = makeFakeSandbox({
+      "/somewhere-else/file.txt": "data",
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox, rootDir: "/app" });
+
+    expect(files).toEqual({});
+  });
+
+  test("defaults to scanning /app when no rootDir is given", async () => {
+    const sandbox = makeFakeSandbox({
+      "/app/server.js": "listen()",
+    });
+
+    const files = await extractFilesFromSandbox({ sandbox });
+
+    expect(files).toEqual({ "server.js": "listen()" });
+  });
+});

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractFilesFromSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractFilesFromSandbox.ts
@@ -1,0 +1,85 @@
+import type { Sandbox } from "@vercel/sandbox";
+import { Files } from "../CodingAgentAppDevelopmentEval";
+
+/** Directories that never contain agent-authored source worth collecting. */
+const IGNORED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "__pycache__",
+  ".venv",
+  "venv",
+  "vendor",
+  "target",
+  "dist",
+  "build",
+]);
+
+/** Files larger than this are skipped — they're almost always binaries or lockfiles. */
+const MAX_FILE_SIZE_BYTES = 100_000;
+
+/** Default working directory the coding agent builds its app in. */
+const DEFAULT_ROOT_DIR = "/app";
+
+/**
+ * Recursively read the application files an agent generated inside a sandbox.
+ *
+ * Walks `rootDir`, skipping dependency/build directories, dotfiles, and files
+ * over {@link MAX_FILE_SIZE_BYTES}. Returns a map of path (relative to
+ * `rootDir`) to file contents — the {@link Files} shape consumed by scorers
+ * and {@link extractDbLibrariesUsed}.
+ */
+export async function extractFilesFromSandbox({
+  sandbox,
+  rootDir = DEFAULT_ROOT_DIR,
+}: {
+  sandbox: Sandbox;
+  rootDir?: string;
+}): Promise<Files> {
+  const files: Files = {};
+  await collectDir({ sandbox, rootDir, currentDir: rootDir, files });
+  return files;
+}
+
+async function collectDir({
+  sandbox,
+  rootDir,
+  currentDir,
+  files,
+}: {
+  sandbox: Sandbox;
+  rootDir: string;
+  currentDir: string;
+  files: Files;
+}): Promise<void> {
+  let entries: Awaited<ReturnType<typeof sandbox.fs.readdir>>;
+  try {
+    entries = await sandbox.fs.readdir(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const name = typeof entry === "string" ? entry : entry.name;
+    if (name.startsWith(".") || IGNORED_DIRS.has(name)) continue;
+
+    const fullPath = `${currentDir}/${name}`;
+    const isDir = typeof entry === "string" ? false : entry.isDirectory();
+
+    if (isDir) {
+      await collectDir({ sandbox, rootDir, currentDir: fullPath, files });
+      continue;
+    }
+
+    try {
+      const stats = await sandbox.fs.stat(fullPath);
+      if (stats.size > MAX_FILE_SIZE_BYTES) continue;
+
+      const content = await sandbox.fs.readFile(fullPath, "utf8");
+      if (typeof content === "string") {
+        files[fullPath.slice(rootDir.length + 1)] = content;
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+}

--- a/packages/benchmarks/src/coding-agent-app-development/utils/index.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/index.ts
@@ -1,0 +1,6 @@
+export { extractFilesFromSandbox } from "./extractFilesFromSandbox";
+export {
+  extractDbLibrariesUsed,
+  DB_LIBRARIES,
+  type DetectedDbLibrary,
+} from "./extractDbLibrariesUsed";


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1972

## Changes

Implements the **Utils** section of the app-building benchmark spec, in `packages/benchmarks/src/coding-agent-app-development/utils/`. Refactored from Helen's skunkworks (#13) into the coding-agent-app-development package created in #14.

- **`extractFilesFromSandbox({ sandbox, rootDir? })`** — refactor of the skunkworks `collectArtifacts.ts`. Recursively reads agent-generated files from a `@vercel/sandbox` into the `Files` (`Record<path, content>`) shape used by this package. Skips dependency/build dirs (`node_modules`, `.git`, `dist`, …), dotfiles, and files over 100 KB. Defaults to scanning `/app`.
- **`extractDbLibrariesUsed({ files })`** — scans every `package.json`'s `dependencies` and `devDependencies` for database libraries, mapping each to a `PrimaryDatabase` (from `classifyAppStack`) or `null` for multi-database ORMs (Prisma, Drizzle, …). Generalizes the skunkworks `MongoDbInPackageJsonScorer` from MongoDB-only to all DBs/ORMs; also scans nested `package.json` files, not just the root.
- Adds the `@vercel/sandbox` dependency to `packages/benchmarks`.

## Notes

- Built with TDD — **18 unit tests**, all passing. `mongodb-rag-core` + `benchmarks` build clean (`tsc -b`); files prettier-formatted.
- The spec's reference paths point at the skunkworks `packages/coding-agent-benchmark/` package; the actual target is `packages/benchmarks/src/coding-agent-app-development/` (the merged location).
- Design choices the spec left open: return shapes (`Files` / `DetectedDbLibrary[]`), `null` for multi-DB ORMs, `rootDir` default `/app`, and committing to `@vercel/sandbox` (the only sandbox referenced, matching the "refactor `collectArtifacts.ts`" instruction).
- Out of scope, pre-existing: `npm run lint` is broken repo-wide because `.eslintrc.cjs` references the `jest/globals` env but `eslint-plugin-jest` isn't installed. Not introduced here.
- Please verify the Jira link — used EAI-1972 (the coding-agent benchmark epic) as the closest known ticket.