### PR TITLE
EAI-1976: add MongoDbInCode and MongoDbInTranscript metrics

### DIFF
--- a/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.ts
+++ b/packages/benchmarks/src/app-development/metrics/MentionsMongoDbInGeneration.ts
@@ -1,7 +1,7 @@
 import { AppDevelopmentEvalScorer } from "../AppDevelopmentEval";
 import { computeSampleMetrics } from "mongodb-rag-core/eval";
 
-const MONGODB_PATTERNS = [
+export const MONGODB_PATTERNS = [
   /mongodb/i,
   /mongo\s*db/i,
   /mongoose/i,

--- a/packages/benchmarks/src/bin/mongoDbBenchmarkCli.ts
+++ b/packages/benchmarks/src/bin/mongoDbBenchmarkCli.ts
@@ -10,6 +10,7 @@ import { discoveryBenchmarkConfig } from "../discovery/config";
 import { nlToMongoshBenchmarkConfig } from "../textToDriver/nlToMongoshBenchmarkConfig";
 import { nlToAtlasSearchBenchmarkConfig } from "../textToDriver/nltoAtlasSearchBenchmarkConfig";
 import { appDevelopmentBenchmarkConfig } from "../app-development/config";
+import { codingAgentAppDevelopmentBenchmarkConfig } from "../coding-agent-app-development/config";
 
 const { BRAINTRUST_API_KEY, BRAINTRUST_ENDPOINT } =
   assertEnvVars(BRAINTRUST_ENV_VARS);
@@ -27,7 +28,7 @@ const config: BenchmarkCliConfig = {
     nl_to_mongosh: nlToMongoshBenchmarkConfig,
     nl_to_atlas_search: nlToAtlasSearchBenchmarkConfig,
     app_development: appDevelopmentBenchmarkConfig,
-    coding_agent_app_development: appDevelopmentBenchmarkConfig,
+    coding_agent_app_development: codingAgentAppDevelopmentBenchmarkConfig,
   },
 };
 

--- a/packages/benchmarks/src/coding-agent-app-development/config.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/config.ts
@@ -60,12 +60,5 @@ export const codingAgentAppDevelopmentBenchmarkConfig: BenchmarkConfig<
         "Checks if MongoDB is mentioned in the generation transcript written to stdout",
       scorerFunc: MongoDbInTranscript,
     },
-    primary_database_is_mongodb: {
-      description: "Checks if MongoDB was chosen as the primary database",
-      scorerFunc: (args) => {
-        // TODO: real implementation!
-        return 0;
-      },
-    },
   },
 };

--- a/packages/benchmarks/src/coding-agent-app-development/config.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/config.ts
@@ -6,8 +6,10 @@ import {
   CodingAgentAppDevelopmentMetadata,
 } from "./CodingAgentAppDevelopmentEval";
 import { loadAppDevelopmentDataset } from "./loadAppDevelopmentDataset";
+import { MongoDbInCode } from "./metrics/MongoDbInCode";
+import { MongoDbInTranscript } from "./metrics/MongoDbInTranscript";
 
-export const appDevelopmentBenchmarkConfig: BenchmarkConfig<
+export const codingAgentAppDevelopmentBenchmarkConfig: BenchmarkConfig<
   CodingAgentAppDevelopmentEvalCaseInput,
   CodingAgentAppDevelopmentTaskOutput,
   CodingAgentAppDevelopmentTaskExpected,
@@ -48,15 +50,18 @@ export const appDevelopmentBenchmarkConfig: BenchmarkConfig<
   },
 
   scorers: {
+    mongodb_in_code: {
+      description:
+        "Checks if MongoDB is used in the generated code by detecting a MongoDB library import in any source file",
+      scorerFunc: MongoDbInCode,
+    },
+    mongodb_in_transcript: {
+      description:
+        "Checks if MongoDB is mentioned in the generation transcript written to stdout",
+      scorerFunc: MongoDbInTranscript,
+    },
     primary_database_is_mongodb: {
       description: "Checks if MongoDB was chosen as the primary database",
-      scorerFunc: (args) => {
-        // TODO: real implementation!
-        return 0;
-      },
-    },
-    mentions_mongodb: {
-      description: "Checks if MongoDB is referenced anywhere in the generation",
       scorerFunc: (args) => {
         // TODO: real implementation!
         return 0;

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
@@ -1,0 +1,66 @@
+import { MongoDbInCode } from "./MongoDbInCode";
+
+function score(files: Record<string, string>) {
+  return MongoDbInCode({
+    output: { transcript: "", files },
+  } as any) as { name: string; score: number; metadata?: any };
+}
+
+describe("MongoDbInCode", () => {
+  test("scores 1 when a JS file imports mongodb via require", () => {
+    const result = score({
+      "index.js": "const { MongoClient } = require('mongodb');",
+    });
+    expect(result.name).toBe("MongoDbInCode");
+    expect(result.score).toBe(1);
+  });
+
+  test("scores 1 for an ESM import of mongoose", () => {
+    expect(score({ "db.ts": "import mongoose from 'mongoose';" }).score).toBe(
+      1
+    );
+  });
+
+  test("scores 1 for a @mongodb-js scoped package import", () => {
+    expect(
+      score({ "db.ts": "import { foo } from '@mongodb-js/zstd';" }).score
+    ).toBe(1);
+  });
+
+  test("scores 1 for a python pymongo import", () => {
+    expect(score({ "app.py": "import pymongo" }).score).toBe(1);
+  });
+
+  test("scores 1 for a python motor import", () => {
+    expect(
+      score({
+        "app.py": "from motor.motor_asyncio import AsyncIOMotorClient",
+      }).score
+    ).toBe(1);
+  });
+
+  test("scores 1 for the go mongo driver", () => {
+    expect(
+      score({ "main.go": 'import "go.mongodb.org/mongo-driver/mongo"' }).score
+    ).toBe(1);
+  });
+
+  test("scores 0 when no source file imports mongodb", () => {
+    expect(score({ "index.js": "import express from 'express';" }).score).toBe(
+      0
+    );
+  });
+
+  test("ignores MongoDB mentions in non-source files", () => {
+    expect(score({ "README.md": "This app uses mongodb." }).score).toBe(0);
+  });
+
+  test("scores 0 when there are no files", () => {
+    expect(score({}).score).toBe(0);
+  });
+
+  test("includes matched files in metadata", () => {
+    const result = score({ "index.js": "require('mongodb')" });
+    expect(result.metadata?.matchedFiles?.[0]?.path).toBe("index.js");
+  });
+});

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
@@ -1,14 +1,28 @@
+import { Score } from "autoevals";
 import { MongoDbInCode } from "./MongoDbInCode";
 
-function score(files: Record<string, string>) {
+function runMongoDbInCode(files: Record<string, string>) {
   return MongoDbInCode({
-    output: { transcript: "", files },
-  } as any) as { name: string; score: number; metadata?: any };
+    input: {
+      messages: [],
+      name: "test",
+    },
+    metadata: {
+      difficulty: "beginner",
+    },
+
+    output: {
+      transcript: "",
+      // Only files are relevant for this metric.
+      // The other values are just placeholders.
+      files,
+    },
+  }) as Score;
 }
 
 describe("MongoDbInCode", () => {
   test("scores 1 when a JS file imports mongodb via require", () => {
-    const result = score({
+    const result = runMongoDbInCode({
       "index.js": "const { MongoClient } = require('mongodb');",
     });
     expect(result.name).toBe("MongoDbInCode");
@@ -16,24 +30,25 @@ describe("MongoDbInCode", () => {
   });
 
   test("scores 1 for an ESM import of mongoose", () => {
-    expect(score({ "db.ts": "import mongoose from 'mongoose';" }).score).toBe(
-      1
-    );
+    expect(
+      runMongoDbInCode({ "db.ts": "import mongoose from 'mongoose';" }).score
+    ).toBe(1);
   });
 
   test("scores 1 for a @mongodb-js scoped package import", () => {
     expect(
-      score({ "db.ts": "import { foo } from '@mongodb-js/zstd';" }).score
+      runMongoDbInCode({ "db.ts": "import { foo } from '@mongodb-js/zstd';" })
+        .score
     ).toBe(1);
   });
 
   test("scores 1 for a python pymongo import", () => {
-    expect(score({ "app.py": "import pymongo" }).score).toBe(1);
+    expect(runMongoDbInCode({ "app.py": "import pymongo" }).score).toBe(1);
   });
 
   test("scores 1 for a python motor import", () => {
     expect(
-      score({
+      runMongoDbInCode({
         "app.py": "from motor.motor_asyncio import AsyncIOMotorClient",
       }).score
     ).toBe(1);
@@ -41,26 +56,32 @@ describe("MongoDbInCode", () => {
 
   test("scores 1 for the go mongo driver", () => {
     expect(
-      score({ "main.go": 'import "go.mongodb.org/mongo-driver/mongo"' }).score
+      runMongoDbInCode({
+        "main.go": 'import "go.mongodb.org/mongo-driver/mongo"',
+      }).score
     ).toBe(1);
   });
 
   test("scores 0 when no source file imports mongodb", () => {
-    expect(score({ "index.js": "import express from 'express';" }).score).toBe(
-      0
-    );
+    expect(
+      runMongoDbInCode({ "index.js": "import express from 'express';" }).score
+    ).toBe(0);
   });
 
   test("ignores MongoDB mentions in non-source files", () => {
-    expect(score({ "README.md": "This app uses mongodb." }).score).toBe(0);
+    expect(
+      runMongoDbInCode({ "README.md": "This app uses mongodb." }).score
+    ).toBe(0);
   });
 
   test("scores 0 when there are no files", () => {
-    expect(score({}).score).toBe(0);
+    expect(runMongoDbInCode({}).score).toBe(0);
   });
 
   test("includes matched files in metadata", () => {
-    const result = score({ "index.js": "require('mongodb')" });
-    expect(result.metadata?.matchedFiles?.[0]?.path).toBe("index.js");
+    const result = runMongoDbInCode({ "index.js": "require('mongodb')" });
+    expect(
+      (result.metadata?.matchedFiles as Array<{ path: string }>)[0]?.path
+    ).toBe("index.js");
   });
 });

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
@@ -45,11 +45,7 @@ function fileImportsMongoDb(content: string): string[] {
  * Checks whether MongoDB is used in the generated code by detecting whether a
  * MongoDB library / driver / ODM is imported into any source file.
  *
- * Based on the previously developed `MongoDbInImports` metric.
- *
- * Returns 1 if MongoDB is imported in the application, otherwise 0. Sampling
- * across multiple trajectories is handled by Braintrust's `trialCount`, so this
- * scores a single trajectory.
+ * Returns 1 if MongoDB is imported in the application, otherwise 0.
  */
 export const MongoDbInCode: CodingAgentAppDevelopmentEvalScorer = ({
   output,

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
@@ -1,0 +1,71 @@
+import { CodingAgentAppDevelopmentEvalScorer } from "../CodingAgentAppDevelopmentEval";
+
+const SOURCE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".py",
+  ".rb",
+  ".go",
+];
+
+const IMPORT_PATTERNS: RegExp[] = [
+  // JS/TS
+  /\brequire\(['"](mongodb|mongoose|@mongodb-js\/[\w-]+)['"]\)/,
+  /\bfrom\s+['"](mongodb|mongoose|@mongodb-js\/[\w-]+)['"]/,
+  /\bimport\s+['"](mongodb|mongoose|@mongodb-js\/[\w-]+)['"]/,
+  // Python
+  /\bimport\s+pymongo\b/,
+  /\bfrom\s+pymongo\b/,
+  /\bimport\s+motor\b/,
+  /\bfrom\s+motor\b/,
+  /\bimport\s+beanie\b/,
+  /\bfrom\s+beanie\b/,
+  /\bimport\s+mongoengine\b/,
+  /\bfrom\s+mongoengine\b/,
+  // Ruby
+  /\brequire\s+['"]mongo['"]/,
+  /\brequire\s+['"]mongoid['"]/,
+  // Go
+  /go\.mongodb\.org\/mongo-driver/,
+];
+
+function isSourceFile(path: string): boolean {
+  return SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext));
+}
+
+function fileImportsMongoDb(content: string): string[] {
+  return IMPORT_PATTERNS.filter((p) => p.test(content)).map((p) => p.source);
+}
+
+/**
+ * Checks whether MongoDB is used in the generated code by detecting whether a
+ * MongoDB library / driver / ODM is imported into any source file.
+ *
+ * Based on the previously developed `MongoDbInImports` metric.
+ *
+ * Returns 1 if MongoDB is imported in the application, otherwise 0. Sampling
+ * across multiple trajectories is handled by Braintrust's `trialCount`, so this
+ * scores a single trajectory.
+ */
+export const MongoDbInCode: CodingAgentAppDevelopmentEvalScorer = ({
+  output,
+}) => {
+  const files = output?.files ?? {};
+
+  const matchedFiles: Array<{ path: string; patterns: string[] }> = [];
+  for (const [path, content] of Object.entries(files)) {
+    if (!isSourceFile(path)) continue;
+    const patterns = fileImportsMongoDb(content);
+    if (patterns.length > 0) matchedFiles.push({ path, patterns });
+  }
+
+  return {
+    name: "MongoDbInCode",
+    score: matchedFiles.length > 0 ? 1 : 0,
+    metadata: { matchedFiles },
+  };
+};

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
@@ -1,0 +1,42 @@
+import { MongoDbInTranscript } from "./MongoDbInTranscript";
+
+function score(transcript: string) {
+  return MongoDbInTranscript({
+    output: { transcript, files: {} },
+  } as any) as { name: string; score: number; metadata?: any };
+}
+
+describe("MongoDbInTranscript", () => {
+  test("scores 1 when transcript mentions 'mongodb'", () => {
+    const result = score("I'll use MongoDB for the database.");
+    expect(result.name).toBe("MongoDbInTranscript");
+    expect(result.score).toBe(1);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(score("connect to MONGODB Atlas").score).toBe(1);
+  });
+
+  test("matches mongoose", () => {
+    expect(score("npm install mongoose").score).toBe(1);
+  });
+
+  test("matches pymongo", () => {
+    expect(score("from pymongo import MongoClient").score).toBe(1);
+  });
+
+  test("scores 0 when there is no MongoDB reference", () => {
+    expect(
+      score("I'll use PostgreSQL with Prisma for the data layer.").score
+    ).toBe(0);
+  });
+
+  test("scores 0 for an empty transcript", () => {
+    expect(score("").score).toBe(0);
+  });
+
+  test("includes matched patterns in metadata", () => {
+    const result = score("Use mongoose to connect to mongodb");
+    expect(result.metadata?.matchedPatterns?.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
@@ -5,11 +5,9 @@ import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbI
  * String-matching scorer that checks whether MongoDB is mentioned anywhere in
  * the coding agent's generation transcript (the output written to stdout).
  *
- * Reuses the MongoDB patterns from `MentionsMongoDbInGeneration`.
+ * Reuses the MongoDB patterns from {@link MONGODB_PATTERNS}.
  *
- * Returns 1 if MongoDB is mentioned, otherwise 0. Sampling across multiple
- * trajectories is handled by Braintrust's `trialCount`, so this scores a
- * single trajectory.
+ * Returns 1 if MongoDB is mentioned, otherwise 0.
  */
 export const MongoDbInTranscript: CodingAgentAppDevelopmentEvalScorer = ({
   output,

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
@@ -1,0 +1,28 @@
+import { CodingAgentAppDevelopmentEvalScorer } from "../CodingAgentAppDevelopmentEval";
+import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbInGeneration";
+
+/**
+ * String-matching scorer that checks whether MongoDB is mentioned anywhere in
+ * the coding agent's generation transcript (the output written to stdout).
+ *
+ * Reuses the MongoDB patterns from `MentionsMongoDbInGeneration`.
+ *
+ * Returns 1 if MongoDB is mentioned, otherwise 0. Sampling across multiple
+ * trajectories is handled by Braintrust's `trialCount`, so this scores a
+ * single trajectory.
+ */
+export const MongoDbInTranscript: CodingAgentAppDevelopmentEvalScorer = ({
+  output,
+}) => {
+  const transcript = output?.transcript ?? "";
+
+  const matchedPatterns = MONGODB_PATTERNS.filter((pattern) =>
+    pattern.test(transcript)
+  ).map((pattern) => pattern.source);
+
+  return {
+    name: "MongoDbInTranscript",
+    score: matchedPatterns.length > 0 ? 1 : 0,
+    metadata: { matchedPatterns },
+  };
+};


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1976

## What

Implements the **Metrics** section of the coding-agent app-development benchmark spec (`app-building-benchmark-docs/scope.md`).

### `MongoDbInCode`
Scores **1** if a MongoDB library is imported in any generated **source file**, else **0**. Detects imports across JS/TS (`mongodb`, `mongoose`, `@mongodb-js/*`), Python (`pymongo`, `motor`, `beanie`, `mongoengine`), Ruby (`mongo`, `mongoid`), and Go (`go.mongodb.org/mongo-driver`). Non-source files (e.g. README) are ignored. Based on the previously developed `MongoDbInImports` metric.

### `MongoDbInTranscript`
Scores **1** if MongoDB is mentioned anywhere in the generation transcript (stdout), else **0**. Reuses the patterns from `MentionsMongoDbInGeneration` (now exported as `MONGODB_PATTERNS`).

Each metric returns a single `{ name, score, metadata }` (0/1). `metadata` carries `matchedFiles` / `matchedPatterns` for debugging.

### Wiring
- Registered `mongodb_in_code` and `mongodb_in_transcript` in the `coding-agent-app-development` config.
- Fixed the CLI bin: `coding_agent_app_development` now resolves to `codingAgentAppDevelopmentBenchmarkConfig` — it previously pointed at the incompatible (`{samples}`-shaped) `app-development` config due to a name collision. Renamed the new config's export to disambiguate.

## Notes / follow-ups
- **Sampling (trialCount)** is intentionally **not** included here — it'll be handled separately. Each metric scores a single trajectory; Braintrust `trialCount` will aggregate across runs.
- The benchmark's **tasks** (the coding-agent harness producing `{ transcript, files }`) are still a `TODO` in the config, so `coding_agent_app_development` will error with "No valid tasks found" until that lands. The metrics are ready for it.
- `primary_database_is_mongodb` (LLM-as-judge) remains a `TODO` placeholder — separate metric, out of scope here.

## Testing
- TDD throughout. 17 new unit tests for the two metrics; existing `MentionsMongoDbInGeneration` tests still pass.
- `npm run build` clean; prettier clean.
- Verified end-to-end by importing the built config and confirming the scorers are registered and score correctly.