### PR TITLE
EAI-1975 Add coding agent harnesses

### DIFF
--- a/packages/benchmarks/src/benchmarkModels.ts
+++ b/packages/benchmarks/src/benchmarkModels.ts
@@ -41,6 +41,8 @@ export const MODELS = (
     "nova-lite-v1:0",
     "nova-pro-v1:0",
     "mistral-large-2",
+    "azure/claude-sonnet-4-6",
+    "azure/claude-haiku-4-5",
   ] satisfies (typeof models)[number]["label"][]
 ).map((label) => {
   const model = models.find((m) => m.label === label);

--- a/packages/benchmarks/src/coding-agent-app-development/agents.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/agents.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { OUTPUT_DIR } from "./prompts";
 
 export interface AgentConfig {
   id: string;
@@ -6,7 +7,7 @@ export interface AgentConfig {
      @example
      ["npm install -g @anthropic-ai/claude-code"]
    */
-  buildSetupCommands: (env: Record<string, string>) => string[];
+  buildSetupCommands: (env: Record<string, string>, model: string) => string[];
   /** 
      @example
      (promptFilePath, model) => `claude --print --model ${model} < ${promptFilePath}`
@@ -70,6 +71,49 @@ EOF`,
     ],
     buildMainCommand: (promptFilePath, model) =>
       `codex exec --sandbox danger-full-access --skip-git-repo-check --model ${model} - < ${promptFilePath}`,
+    env: {
+      OPENAI_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
+      OPENAI_API_KEY: process.env.BRAINTRUST_API_KEY,
+    },
+    buildBraintrustParentEnv: (_env, braintrustParent) => ({
+      BRAINTRUST_PARENT: braintrustParent,
+    }),
+  },
+  {
+    id: "opencode/opencode",
+    buildSetupCommands: (env, model) => {
+      const config = {
+        $schema: "https://opencode.ai/config.json",
+        provider: {
+          braintrust: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "Braintrust",
+            options: {
+              baseURL: env.OPENAI_BASE_URL,
+              apiKey: "{env:OPENAI_API_KEY}",
+              headers: {
+                "x-bt-parent": "{env:BRAINTRUST_PARENT}",
+              },
+            },
+            models: {
+              [model]: {
+                name: model,
+              },
+            },
+          },
+        },
+      };
+      return [
+        "npm install -g opencode-ai",
+        `cat > ${OUTPUT_DIR}/opencode.json <<'EOF'\n${JSON.stringify(
+          config,
+          null,
+          2
+        )}\nEOF`,
+      ];
+    },
+    buildMainCommand: (promptFilePath, model) =>
+      `opencode run --dir ${OUTPUT_DIR} --model braintrust/${model} --dangerously-skip-permissions "Build the app described in the attached prompt file." --file ${promptFilePath}`,
     env: {
       OPENAI_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
       OPENAI_API_KEY: process.env.BRAINTRUST_API_KEY,

--- a/packages/benchmarks/src/coding-agent-app-development/agents.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/agents.ts
@@ -9,9 +9,9 @@ export interface AgentConfig {
   buildSetupCommands: (env: Record<string, string>) => string[];
   /** 
      @example
-     (prompt, model) => `echo '${prompt}' | claude --print --model ${model}`
+     (promptFilePath, model) => `claude --print --model ${model} < ${promptFilePath}`
    */
-  buildMainCommand: (prompt: string, model: string) => string;
+  buildMainCommand: (promptFilePath: string, model: string) => string;
 
   /** 
      @example
@@ -29,8 +29,8 @@ export const AGENTS: AgentConfig[] = [
   {
     id: "anthropic/claude-code",
     buildSetupCommands: () => ["npm install -g @anthropic-ai/claude-code"],
-    buildMainCommand: (prompt, model) =>
-      `echo '${prompt}' | claude --print --model ${model} --permission-mode bypassPermissions --dangerously-skip-permissions `,
+    buildMainCommand: (promptFilePath, model) =>
+      `claude --print --model ${model} --permission-mode bypassPermissions --dangerously-skip-permissions < ${promptFilePath}`,
     env: {
       ANTHROPIC_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
       ANTHROPIC_API_KEY: process.env.BRAINTRUST_API_KEY,

--- a/packages/benchmarks/src/coding-agent-app-development/agents.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/agents.ts
@@ -21,6 +21,14 @@ export interface AgentConfig {
      }
    */
   env: Record<string, string>;
+
+  /**
+   * Adds agent-specific environment variables for Braintrust trace propagation.
+   */
+  buildBraintrustParentEnv?: (
+    env: Record<string, string>,
+    braintrustParent: string
+  ) => Record<string, string>;
 }
 assert(process.env.BRAINTRUST_ENDPOINT, "BRAINTRUST_ENDPOINT is not set");
 assert(process.env.BRAINTRUST_API_KEY, "BRAINTRUST_API_KEY is not set");
@@ -36,5 +44,38 @@ export const AGENTS: AgentConfig[] = [
       ANTHROPIC_API_KEY: process.env.BRAINTRUST_API_KEY,
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
     },
+    buildBraintrustParentEnv: (env, braintrustParent) => {
+      const braintrustHeader = `x-bt-parent: ${braintrustParent}`;
+      const existingHeaders = env.ANTHROPIC_CUSTOM_HEADERS;
+      return {
+        ANTHROPIC_CUSTOM_HEADERS: existingHeaders
+          ? `${existingHeaders}\n${braintrustHeader}`
+          : braintrustHeader,
+      };
+    },
+  },
+  {
+    id: "openai/codex",
+    buildSetupCommands: (env) => [
+      "npm install -g @openai/codex",
+      `mkdir -p ~/.codex && cat > ~/.codex/config.toml <<'EOF'
+model_provider = "braintrust"
+
+[model_providers.braintrust]
+name = "Braintrust"
+base_url = "${env.OPENAI_BASE_URL}"
+env_key = "OPENAI_API_KEY"
+env_http_headers = { "x-bt-parent" = "BRAINTRUST_PARENT" }
+EOF`,
+    ],
+    buildMainCommand: (promptFilePath, model) =>
+      `codex exec --sandbox danger-full-access --skip-git-repo-check --model ${model} - < ${promptFilePath}`,
+    env: {
+      OPENAI_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
+      OPENAI_API_KEY: process.env.BRAINTRUST_API_KEY,
+    },
+    buildBraintrustParentEnv: (_env, braintrustParent) => ({
+      BRAINTRUST_PARENT: braintrustParent,
+    }),
   },
 ];

--- a/packages/benchmarks/src/coding-agent-app-development/agents.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/agents.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 export interface AgentConfig {
   id: string;
   /** 
@@ -20,7 +22,19 @@ export interface AgentConfig {
    */
   env: Record<string, string>;
 }
+assert(process.env.BRAINTRUST_ENDPOINT, "BRAINTRUST_ENDPOINT is not set");
+assert(process.env.BRAINTRUST_API_KEY, "BRAINTRUST_API_KEY is not set");
 
 export const AGENTS: AgentConfig[] = [
-  // TODO: EAI-1975 implement these!!
+  {
+    id: "anthropic/claude-code",
+    buildSetupCommands: () => ["npm install -g @anthropic-ai/claude-code"],
+    buildMainCommand: (prompt, model) =>
+      `echo '${prompt}' | claude --print --model ${model} --permission-mode bypassPermissions --dangerously-skip-permissions `,
+    env: {
+      ANTHROPIC_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
+      ANTHROPIC_API_KEY: process.env.BRAINTRUST_API_KEY,
+      CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
+    },
+  },
 ];

--- a/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.test.ts
@@ -9,7 +9,13 @@ const mockGenerateAppInSandbox = generateAppInSandbox as jest.MockedFunction<
   typeof generateAppInSandbox
 >;
 
-const mockHooks = {} as any;
+function makeMockHooks() {
+  return {
+    span: {
+      export: jest.fn().mockResolvedValue("span-export-value"),
+    },
+  } as any;
+}
 
 function makeInput() {
   return {
@@ -49,14 +55,17 @@ describe("makeAppDevelopmentTask", () => {
     });
     const args = makeTaskArgs();
     const input = makeInput();
+    const hooks = makeMockHooks();
 
     const task = makeAppDevelopmentTask(args);
-    await task(input, mockHooks);
+    await task(input, hooks);
 
+    expect(hooks.span.export).toHaveBeenCalledTimes(1);
     expect(mockGenerateAppInSandbox).toHaveBeenCalledTimes(1);
     expect(mockGenerateAppInSandbox).toHaveBeenCalledWith({
       ...args,
       input,
+      braintrustParent: "span-export-value",
     });
   });
 
@@ -83,7 +92,7 @@ describe("makeAppDevelopmentTask", () => {
     });
 
     const task = makeAppDevelopmentTask(makeTaskArgs());
-    const result = await task(makeInput(), mockHooks);
+    const result = await task(makeInput(), makeMockHooks());
 
     expect(result).toEqual({
       files,
@@ -102,7 +111,7 @@ describe("makeAppDevelopmentTask", () => {
     });
 
     const task = makeAppDevelopmentTask(makeTaskArgs());
-    const result = await task(makeInput(), mockHooks);
+    const result = await task(makeInput(), makeMockHooks());
 
     expect(result).toEqual({
       files: {},
@@ -118,6 +127,8 @@ describe("makeAppDevelopmentTask", () => {
 
     const task = makeAppDevelopmentTask(makeTaskArgs());
 
-    await expect(task(makeInput(), mockHooks)).rejects.toThrow(generationError);
+    await expect(task(makeInput(), makeMockHooks())).rejects.toThrow(
+      generationError
+    );
   });
 });

--- a/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.ts
@@ -7,16 +7,20 @@ import {
   CodingAgentAppDevelopmentEvalTask,
   CodingAgentAppDevelopmentTaskOutput,
 } from "./CodingAgentAppDevelopmentEval";
+import { EvalHooks, EvalParameters } from "mongodb-rag-core/braintrust";
 
 export function makeAppDevelopmentTask(
   args: Omit<GenerateAppInSandboxParams, "input">
 ): CodingAgentAppDevelopmentEvalTask {
   return async function appDevelopmentTask(
-    input: CodingAgentAppDevelopmentEvalCaseInput
+    input: CodingAgentAppDevelopmentEvalCaseInput,
+    hooks: EvalHooks<void, any, EvalParameters>
   ) {
+    const braintrustParent = await hooks.span.export();
     const { files, databaseLibraries, stdout } = await generateAppInSandbox({
       ...args,
       input,
+      braintrustParent,
     });
     return {
       files,

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
@@ -88,16 +88,22 @@ function makeAgentConfig({
   env = { AGENT_API_KEY: "test-key" },
   setupCommands = ["npm install -g test-agent"],
   mainCommand = "test-agent --run",
+  buildBraintrustParentEnv,
 }: {
   env?: Record<string, string>;
   setupCommands?: string[];
   mainCommand?: string;
+  buildBraintrustParentEnv?: (
+    env: Record<string, string>,
+    braintrustParent: string
+  ) => Record<string, string>;
 } = {}) {
   return {
     id: "test-agent",
     env,
     buildSetupCommands: jest.fn().mockReturnValue(setupCommands),
     buildMainCommand: jest.fn().mockReturnValue(mainCommand),
+    buildBraintrustParentEnv,
   };
 }
 
@@ -164,12 +170,15 @@ describe("generateAppInSandbox", () => {
     });
   });
 
-  test("adds the Braintrust parent span to Claude Code custom headers", async () => {
+  test("adds the Braintrust parent span using the agent-specific env strategy", async () => {
+    const buildBraintrustParentEnv = jest.fn().mockReturnValue({
+      AGENT_CUSTOM_HEADERS: "x-bt-parent: span-export-value",
+    });
     const agent = makeAgentConfig({
       env: {
         AGENT_API_KEY: "test-key",
-        ANTHROPIC_CUSTOM_HEADERS: "x-existing-header: test",
       },
+      buildBraintrustParentEnv,
     });
     const sandbox = makeMockSandbox();
     mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
@@ -182,13 +191,16 @@ describe("generateAppInSandbox", () => {
       braintrustParent: "span-export-value",
     });
 
+    expect(buildBraintrustParentEnv).toHaveBeenCalledWith(
+      { AGENT_API_KEY: "test-key" },
+      "span-export-value"
+    );
     expect(mockCreateSandbox).toHaveBeenCalledWith({
       resources: { vcpus: 2 },
       timeout: 3 * 60 * 60 * 1000,
       env: {
         AGENT_API_KEY: "test-key",
-        ANTHROPIC_CUSTOM_HEADERS:
-          "x-existing-header: test\nx-bt-parent: span-export-value",
+        AGENT_CUSTOM_HEADERS: "x-bt-parent: span-export-value",
       },
     });
   });

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
@@ -18,10 +18,14 @@ type MockSandbox = Pick<Sandbox, "runCommand" | "stop" | "fs">;
 
 function makeMockSandbox({
   files = {},
-  mainCommandResult = { stdout: "agent stdout", stderr: "agent stderr" },
+  mainCommandResult = {
+    stdout: "agent stdout",
+    stderr: "agent stderr",
+    exitCode: 0,
+  },
 }: {
   files?: Record<string, string | { content: string; size: number }>;
-  mainCommandResult?: { stdout: string; stderr: string };
+  mainCommandResult?: { stdout: string; stderr: string; exitCode?: number };
 } = {}): MockSandbox {
   const fileMap = new Map<string, { content: string; size: number }>();
   for (const [path, value] of Object.entries(files)) {
@@ -71,6 +75,7 @@ function makeMockSandbox({
     runCommand: jest.fn().mockResolvedValue({
       stdout: jest.fn().mockResolvedValue(mainCommandResult.stdout),
       stderr: jest.fn().mockResolvedValue(mainCommandResult.stderr),
+      exitCode: mainCommandResult.exitCode ?? 0,
     }),
     stop: jest.fn().mockResolvedValue(undefined),
     fs,
@@ -157,6 +162,56 @@ describe("generateAppInSandbox", () => {
     });
   });
 
+  test("adds the Braintrust parent span to Claude Code custom headers", async () => {
+    const agent = makeAgentConfig({
+      env: {
+        AGENT_API_KEY: "test-key",
+        ANTHROPIC_CUSTOM_HEADERS: "x-existing-header: test",
+      },
+    });
+    const sandbox = makeMockSandbox();
+    mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
+
+    await generateAppInSandbox({
+      agent,
+      model: "test-model",
+      systemPrompt: "Build complete apps.",
+      input: makeInput(),
+      braintrustParent: "span-export-value",
+    });
+
+    expect(mockCreateSandbox).toHaveBeenCalledWith({
+      resources: { vcpus: 2 },
+      timeout: 10 * 60 * 1000,
+      env: {
+        AGENT_API_KEY: "test-key",
+        ANTHROPIC_CUSTOM_HEADERS:
+          "x-existing-header: test\nx-bt-parent: span-export-value",
+      },
+    });
+  });
+
+  test("creates the output directory before setup commands", async () => {
+    const sandbox = makeMockSandbox();
+    mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
+
+    await generateAppInSandbox({
+      agent: makeAgentConfig(),
+      model: "test-model",
+      systemPrompt: "Build complete apps.",
+      input: makeInput(),
+    });
+
+    expect(sandbox.runCommand).toHaveBeenNthCalledWith(1, {
+      cmd: "sh",
+      args: [
+        "-c",
+        "mkdir -p /app && chown -R vercel-sandbox:vercel-sandbox /app",
+      ],
+      sudo: true,
+    });
+  });
+
   test("runs setup commands before the main agent command", async () => {
     const agent = makeAgentConfig({
       setupCommands: ["install agent", "authenticate agent"],
@@ -173,18 +228,19 @@ describe("generateAppInSandbox", () => {
     });
 
     expect(agent.buildSetupCommands).toHaveBeenCalledWith(agent.env);
-    expect(sandbox.runCommand).toHaveBeenNthCalledWith(1, "sh", [
+    expect(sandbox.runCommand).toHaveBeenNthCalledWith(2, "sh", [
       "-c",
       "install agent",
     ]);
-    expect(sandbox.runCommand).toHaveBeenNthCalledWith(2, "sh", [
+    expect(sandbox.runCommand).toHaveBeenNthCalledWith(3, "sh", [
       "-c",
       "authenticate agent",
     ]);
-    expect(sandbox.runCommand).toHaveBeenNthCalledWith(3, "sh", [
-      "-c",
-      "run agent",
-    ]);
+    expect(sandbox.runCommand).toHaveBeenNthCalledWith(4, {
+      cmd: "sh",
+      args: ["-c", "run agent"],
+      cwd: "/app",
+    });
   });
 
   test("passes the formatted conversation prompt and model to the agent command builder", async () => {
@@ -231,8 +287,12 @@ Use MongoDB for storage.
       input: makeInput(),
     });
 
-    expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
-    expect(sandbox.runCommand).toHaveBeenCalledWith("sh", ["-c", "run agent"]);
+    expect(sandbox.runCommand).toHaveBeenCalledTimes(2);
+    expect(sandbox.runCommand).toHaveBeenLastCalledWith({
+      cmd: "sh",
+      args: ["-c", "run agent"],
+      cwd: "/app",
+    });
   });
 
   test("stops the sandbox after a successful run", async () => {
@@ -283,6 +343,35 @@ Use MongoDB for storage.
         input: makeInput(),
       })
     ).rejects.toThrow(mainError);
+
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws stdout and stderr when the main command exits nonzero", async () => {
+    const sandbox = makeMockSandbox();
+    (sandbox.runCommand as jest.Mock)
+      .mockResolvedValueOnce({
+        stdout: jest.fn().mockResolvedValue(""),
+        stderr: jest.fn().mockResolvedValue(""),
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: jest.fn().mockResolvedValue("agent stdout"),
+        stderr: jest.fn().mockResolvedValue("agent stderr"),
+        exitCode: 1,
+      });
+    mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
+
+    await expect(
+      generateAppInSandbox({
+        agent: makeAgentConfig({ setupCommands: [], mainCommand: "run agent" }),
+        model: "test-model",
+        systemPrompt: "Build complete apps.",
+        input: makeInput(),
+      })
+    ).rejects.toThrow(
+      "Agent command exited with code 1\nSTDOUT:\nagent stdout\nSTDERR:\nagent stderr"
+    );
 
     expect(sandbox.stop).toHaveBeenCalledTimes(1);
   });

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
@@ -16,6 +16,24 @@ const describeIfNotCi = process.env.CI ? describe.skip : describe;
 
 type MockSandbox = Pick<Sandbox, "runCommand" | "stop" | "fs" | "writeFiles">;
 
+function makeMockCommand({
+  stdout = "",
+  stderr = "",
+  exitCode = 0,
+}: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+} = {}) {
+  return {
+    wait: jest.fn().mockResolvedValue(undefined),
+    stdout: jest.fn().mockResolvedValue(stdout),
+    stderr: jest.fn().mockResolvedValue(stderr),
+    exitCode,
+    cmdId: "test-command-id",
+  };
+}
+
 function makeMockSandbox({
   files = {},
   mainCommandResult = {
@@ -72,12 +90,7 @@ function makeMockSandbox({
   };
 
   return {
-    runCommand: jest.fn().mockResolvedValue({
-      stdout: jest.fn().mockResolvedValue(mainCommandResult.stdout),
-      stderr: jest.fn().mockResolvedValue(mainCommandResult.stderr),
-      exitCode: mainCommandResult.exitCode ?? 0,
-      cmdId: "test-command-id",
-    }),
+    runCommand: jest.fn().mockResolvedValue(makeMockCommand(mainCommandResult)),
     writeFiles: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn().mockResolvedValue(undefined),
     fs,
@@ -241,7 +254,10 @@ describe("generateAppInSandbox", () => {
       input: makeInput(),
     });
 
-    expect(agent.buildSetupCommands).toHaveBeenCalledWith(agent.env);
+    expect(agent.buildSetupCommands).toHaveBeenCalledWith(
+      agent.env,
+      "test-model"
+    );
     expect(sandbox.runCommand).toHaveBeenNthCalledWith(2, "sh", [
       "-c",
       "install agent",
@@ -320,16 +336,10 @@ Use MongoDB for storage.
   test("does not fail a detached main command with an unknown exit code", async () => {
     const sandbox = makeMockSandbox();
     (sandbox.runCommand as jest.Mock)
-      .mockResolvedValueOnce({
-        stdout: jest.fn().mockResolvedValue(""),
-        stderr: jest.fn().mockResolvedValue(""),
-        exitCode: 0,
-      })
-      .mockResolvedValueOnce({
-        stdout: jest.fn().mockResolvedValue("agent completed"),
-        stderr: jest.fn().mockResolvedValue(""),
-        exitCode: null,
-      });
+      .mockResolvedValueOnce(makeMockCommand())
+      .mockResolvedValueOnce(
+        makeMockCommand({ stdout: "agent completed", exitCode: null })
+      );
     mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
 
     await expect(
@@ -381,7 +391,7 @@ Use MongoDB for storage.
     const mainError = new Error("main command failed");
     const sandbox = makeMockSandbox();
     (sandbox.runCommand as jest.Mock)
-      .mockResolvedValueOnce({ stdout: "setup stdout", stderr: "" })
+      .mockResolvedValueOnce(makeMockCommand({ stdout: "setup stdout" }))
       .mockRejectedValueOnce(mainError);
     mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
 
@@ -400,16 +410,14 @@ Use MongoDB for storage.
   test("throws stdout and stderr when the main command exits nonzero", async () => {
     const sandbox = makeMockSandbox();
     (sandbox.runCommand as jest.Mock)
-      .mockResolvedValueOnce({
-        stdout: jest.fn().mockResolvedValue(""),
-        stderr: jest.fn().mockResolvedValue(""),
-        exitCode: 0,
-      })
-      .mockResolvedValueOnce({
-        stdout: jest.fn().mockResolvedValue("agent stdout"),
-        stderr: jest.fn().mockResolvedValue("agent stderr"),
-        exitCode: 1,
-      });
+      .mockResolvedValueOnce(makeMockCommand())
+      .mockResolvedValueOnce(
+        makeMockCommand({
+          stdout: "agent stdout",
+          stderr: "agent stderr",
+          exitCode: 1,
+        })
+      );
     mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
 
     await expect(

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
@@ -14,7 +14,7 @@ const mockCreateSandbox = VercelSandbox.create as jest.MockedFunction<
 
 const describeIfNotCi = process.env.CI ? describe.skip : describe;
 
-type MockSandbox = Pick<Sandbox, "runCommand" | "stop" | "fs">;
+type MockSandbox = Pick<Sandbox, "runCommand" | "stop" | "fs" | "writeFiles">;
 
 function makeMockSandbox({
   files = {},
@@ -76,7 +76,9 @@ function makeMockSandbox({
       stdout: jest.fn().mockResolvedValue(mainCommandResult.stdout),
       stderr: jest.fn().mockResolvedValue(mainCommandResult.stderr),
       exitCode: mainCommandResult.exitCode ?? 0,
+      cmdId: "test-command-id",
     }),
+    writeFiles: jest.fn().mockResolvedValue(undefined),
     stop: jest.fn().mockResolvedValue(undefined),
     fs,
   } as unknown as MockSandbox;
@@ -157,7 +159,7 @@ describe("generateAppInSandbox", () => {
 
     expect(mockCreateSandbox).toHaveBeenCalledWith({
       resources: { vcpus: 2 },
-      timeout: 10 * 60 * 1000,
+      timeout: 3 * 60 * 60 * 1000,
       env: agent.env,
     });
   });
@@ -182,7 +184,7 @@ describe("generateAppInSandbox", () => {
 
     expect(mockCreateSandbox).toHaveBeenCalledWith({
       resources: { vcpus: 2 },
-      timeout: 10 * 60 * 1000,
+      timeout: 3 * 60 * 60 * 1000,
       env: {
         AGENT_API_KEY: "test-key",
         ANTHROPIC_CUSTOM_HEADERS:
@@ -240,10 +242,11 @@ describe("generateAppInSandbox", () => {
       cmd: "sh",
       args: ["-c", "run agent"],
       cwd: "/app",
+      detached: true,
     });
   });
 
-  test("passes the formatted conversation prompt and model to the agent command builder", async () => {
+  test("writes the formatted conversation prompt to a file before running the agent", async () => {
     const agent = makeAgentConfig({ mainCommand: "run agent" });
     const sandbox = makeMockSandbox();
     mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
@@ -255,8 +258,10 @@ describe("generateAppInSandbox", () => {
       input: makeInput(),
     });
 
-    expect(agent.buildMainCommand).toHaveBeenCalledWith(
-      `<system>
+    expect(sandbox.writeFiles).toHaveBeenCalledWith([
+      {
+        path: "/tmp/claude-prompt.txt",
+        content: `<system>
 Build complete apps.
 </system>
 <user>
@@ -268,6 +273,10 @@ I'll build it.
 <user>
 Use MongoDB for storage.
 </user>`,
+      },
+    ]);
+    expect(agent.buildMainCommand).toHaveBeenCalledWith(
+      "/tmp/claude-prompt.txt",
       "gpt-test"
     );
   });
@@ -292,6 +301,35 @@ Use MongoDB for storage.
       cmd: "sh",
       args: ["-c", "run agent"],
       cwd: "/app",
+      detached: true,
+    });
+  });
+
+  test("does not fail a detached main command with an unknown exit code", async () => {
+    const sandbox = makeMockSandbox();
+    (sandbox.runCommand as jest.Mock)
+      .mockResolvedValueOnce({
+        stdout: jest.fn().mockResolvedValue(""),
+        stderr: jest.fn().mockResolvedValue(""),
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: jest.fn().mockResolvedValue("agent completed"),
+        stderr: jest.fn().mockResolvedValue(""),
+        exitCode: null,
+      });
+    mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
+
+    await expect(
+      generateAppInSandbox({
+        agent: makeAgentConfig({ setupCommands: [], mainCommand: "run agent" }),
+        model: "test-model",
+        systemPrompt: "Build complete apps.",
+        input: makeInput(),
+      })
+    ).resolves.toMatchObject({
+      stdout: "agent completed",
+      stderr: "",
     });
   });
 

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
@@ -3,6 +3,7 @@ import { CodingAgentAppDevelopmentEvalCaseInput } from "./CodingAgentAppDevelopm
 import { extractDbLibrariesUsed, extractFilesFromSandbox } from "./utils";
 import assert from "assert";
 import { AgentConfig } from "./agents";
+import { OUTPUT_DIR } from "./prompts";
 
 function buildFullPrompt(
   systemPrompt: string,
@@ -20,25 +21,60 @@ export interface GenerateAppInSandboxParams {
   model: string;
   systemPrompt: string;
   input: CodingAgentAppDevelopmentEvalCaseInput;
+  braintrustParent?: string;
 }
+
+function makeSandboxEnv({
+  agentEnv,
+  braintrustParent,
+}: {
+  agentEnv: Record<string, string>;
+  braintrustParent?: string;
+}) {
+  if (!braintrustParent) {
+    return agentEnv;
+  }
+  const braintrustHeader = `x-bt-parent: ${braintrustParent}`;
+  const existingHeaders = agentEnv.ANTHROPIC_CUSTOM_HEADERS;
+  return {
+    ...agentEnv,
+    ANTHROPIC_CUSTOM_HEADERS: existingHeaders
+      ? `${existingHeaders}\n${braintrustHeader}`
+      : braintrustHeader,
+  };
+}
+
 export const generateAppInSandbox = async function ({
   agent,
   model,
   systemPrompt,
   input,
+  braintrustParent,
 }: GenerateAppInSandboxParams) {
   assertSandboxEnv();
   const prompt = buildFullPrompt(systemPrompt, input);
-
+  const sandboxEnv = makeSandboxEnv({
+    agentEnv: agent.env,
+    braintrustParent,
+  });
   let sandbox: Sandbox | undefined;
   try {
     // create sandbox
     sandbox = await Sandbox.create({
       resources: { vcpus: 2 },
       timeout: 10 * 60 * 1000,
-      env: agent.env,
+      env: sandboxEnv,
     });
     assert(sandbox, "Sandbox creation failed");
+
+    await sandbox.runCommand({
+      cmd: "sh",
+      args: [
+        "-c",
+        `mkdir -p ${OUTPUT_DIR} && chown -R vercel-sandbox:vercel-sandbox ${OUTPUT_DIR}`,
+      ],
+      sudo: true,
+    });
 
     // setup agent in sandbox
     const setupCommands = agent.buildSetupCommands(agent.env);
@@ -48,10 +84,26 @@ export const generateAppInSandbox = async function ({
 
     // run agent!
     const fullCommand = agent.buildMainCommand(prompt, model);
-    const { stdout, stderr } = await sandbox.runCommand("sh", [
-      "-c",
-      fullCommand,
-    ]);
+    const command = await sandbox.runCommand({
+      cmd: "sh",
+      args: ["-c", fullCommand],
+      cwd: OUTPUT_DIR,
+    });
+
+    const stdout = await command.stdout().catch((error) => {
+      console.error("failed to read stdout", error);
+      return "";
+    });
+    const stderr = await command.stderr().catch((error) => {
+      console.error("failed to read stderr", error);
+      return "";
+    });
+
+    if (command.exitCode !== 0) {
+      throw new Error(
+        `Agent command exited with code ${command.exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+      );
+    }
 
     const files = await extractFilesFromSandbox({ sandbox });
     const databaseLibraries = extractDbLibrariesUsed({ files });
@@ -59,8 +111,8 @@ export const generateAppInSandbox = async function ({
     return {
       files,
       databaseLibraries,
-      stdout: await stdout(),
-      stderr: await stderr(),
+      stdout,
+      stderr,
     };
   } finally {
     // clean up sandbox

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
@@ -5,6 +5,8 @@ import assert from "assert";
 import { AgentConfig } from "./agents";
 import { OUTPUT_DIR } from "./prompts";
 
+const PROMPT_FILE_PATH = "/tmp/claude-prompt.txt";
+
 function buildFullPrompt(
   systemPrompt: string,
   input: CodingAgentAppDevelopmentEvalCaseInput
@@ -59,10 +61,11 @@ export const generateAppInSandbox = async function ({
   });
   let sandbox: Sandbox | undefined;
   try {
+    const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
     // create sandbox
     sandbox = await Sandbox.create({
       resources: { vcpus: 2 },
-      timeout: 10 * 60 * 1000,
+      timeout: THREE_HOURS_MS,
       env: sandboxEnv,
     });
     assert(sandbox, "Sandbox creation failed");
@@ -82,12 +85,20 @@ export const generateAppInSandbox = async function ({
       await sandbox.runCommand("sh", ["-c", setupCmd]);
     }
 
+    await sandbox.writeFiles([
+      {
+        path: PROMPT_FILE_PATH,
+        content: prompt,
+      },
+    ]);
+
     // run agent!
-    const fullCommand = agent.buildMainCommand(prompt, model);
+    const fullCommand = agent.buildMainCommand(PROMPT_FILE_PATH, model);
     const command = await sandbox.runCommand({
       cmd: "sh",
       args: ["-c", fullCommand],
       cwd: OUTPUT_DIR,
+      detached: true,
     });
 
     const stdout = await command.stdout().catch((error) => {
@@ -99,7 +110,7 @@ export const generateAppInSandbox = async function ({
       return "";
     });
 
-    if (command.exitCode !== 0) {
+    if (command.exitCode !== null && command.exitCode !== 0) {
       throw new Error(
         `Agent command exited with code ${command.exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
       );

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
@@ -76,7 +76,7 @@ export const generateAppInSandbox = async function ({
     });
 
     // setup agent in sandbox
-    const setupCommands = agent.buildSetupCommands(agent.env);
+    const setupCommands = agent.buildSetupCommands(agent.env, model);
     for (const setupCmd of setupCommands) {
       await sandbox.runCommand("sh", ["-c", setupCmd]);
     }
@@ -106,9 +106,6 @@ export const generateAppInSandbox = async function ({
       console.error("failed to read stderr", error);
       return "";
     });
-    if (stderr) {
-      console.error("stderr:", stderr);
-    }
 
     if (command.exitCode !== null && command.exitCode !== 0) {
       throw new Error(

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
@@ -27,22 +27,18 @@ export interface GenerateAppInSandboxParams {
 }
 
 function makeSandboxEnv({
-  agentEnv,
+  agent,
   braintrustParent,
 }: {
-  agentEnv: Record<string, string>;
+  agent: AgentConfig;
   braintrustParent?: string;
 }) {
   if (!braintrustParent) {
-    return agentEnv;
+    return agent.env;
   }
-  const braintrustHeader = `x-bt-parent: ${braintrustParent}`;
-  const existingHeaders = agentEnv.ANTHROPIC_CUSTOM_HEADERS;
   return {
-    ...agentEnv,
-    ANTHROPIC_CUSTOM_HEADERS: existingHeaders
-      ? `${existingHeaders}\n${braintrustHeader}`
-      : braintrustHeader,
+    ...agent.env,
+    ...agent.buildBraintrustParentEnv?.(agent.env, braintrustParent),
   };
 }
 
@@ -56,7 +52,7 @@ export const generateAppInSandbox = async function ({
   assertSandboxEnv();
   const prompt = buildFullPrompt(systemPrompt, input);
   const sandboxEnv = makeSandboxEnv({
-    agentEnv: agent.env,
+    agent,
     braintrustParent,
   });
   let sandbox: Sandbox | undefined;
@@ -101,6 +97,7 @@ export const generateAppInSandbox = async function ({
       detached: true,
     });
 
+    await command.wait();
     const stdout = await command.stdout().catch((error) => {
       console.error("failed to read stdout", error);
       return "";
@@ -109,6 +106,9 @@ export const generateAppInSandbox = async function ({
       console.error("failed to read stderr", error);
       return "";
     });
+    if (stderr) {
+      console.error("stderr:", stderr);
+    }
 
     if (command.exitCode !== null && command.exitCode !== 0) {
       throw new Error(

--- a/packages/benchmarks/src/coding-agent-app-development/prompts.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/prompts.ts
@@ -1,3 +1,7 @@
 export const OUTPUT_DIR = "/app";
 
-export const BASE_SYSTEM_PROMPT = `Build a production-ready Node.js/JavaScript app in the directory ${OUTPUT_DIR}. Do not ask for user input while building the app. Build it completely on your own to completion.`;
+export const BASE_SYSTEM_PROMPT = [
+  `Build a complete, production-ready Node.js/JavaScript app in the directory ${OUTPUT_DIR}.`,
+  "Do not ask for user input while building the app. Build it completely on your own to completion.",
+  "Use a durable, production-appropriate database for persistent application data. Do not use in-memory storage for data that should survive restarts. Avoid SQLite unless the app is clearly local-only, single-user, or embedded.",
+].join(" ");

--- a/packages/benchmarks/src/coding-agent-app-development/prompts.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/prompts.ts
@@ -1,2 +1,3 @@
-export const BASE_SYSTEM_PROMPT =
-  "Put the output Node.js/JavaScript app in the directory /app. Do not ask for user input while building the app. Build it completely on your own to completion.";
+export const OUTPUT_DIR = "/app";
+
+export const BASE_SYSTEM_PROMPT = `Put the output Node.js/JavaScript app in the directory ${OUTPUT_DIR}. Do not ask for user input while building the app. Build it completely on your own to completion.`;

--- a/packages/benchmarks/src/coding-agent-app-development/prompts.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/prompts.ts
@@ -1,3 +1,3 @@
 export const OUTPUT_DIR = "/app";
 
-export const BASE_SYSTEM_PROMPT = `Put the output Node.js/JavaScript app in the directory ${OUTPUT_DIR}. Do not ask for user input while building the app. Build it completely on your own to completion.`;
+export const BASE_SYSTEM_PROMPT = `Build a production-ready Node.js/JavaScript app in the directory ${OUTPUT_DIR}. Do not ask for user input while building the app. Build it completely on your own to completion.`;

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
@@ -103,6 +103,21 @@ describe("extractDbLibrariesUsed", () => {
     });
   });
 
+  test("detects sql.js as sqlite", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: { "sql.js": "^1.14.1" },
+      }),
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "sql.js",
+      database: "sqlite",
+      packageJsonPath: "package.json",
+      field: "dependencies",
+    });
+  });
+
   test("ignores non-database dependencies", () => {
     const files: Files = {
       "package.json": packageJson({

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.test.ts
@@ -88,6 +88,58 @@ describe("extractDbLibrariesUsed", () => {
     expect(byLib["drizzle-orm"]).toBeNull();
   });
 
+  test("infers the concrete database from Prisma schema providers", () => {
+    const files: Files = {
+      "package.json": packageJson({
+        dependencies: { "@prisma/client": "^5.0.0" },
+      }),
+      "prisma/schema.prisma": `
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+      `,
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "prisma:postgresql",
+      database: "postgresql",
+      packageJsonPath: "prisma/schema.prisma",
+      field: "dependencies",
+    });
+  });
+
+  test("maps Prisma sqlite providers to sqlite", () => {
+    const files: Files = {
+      "schema.prisma": `
+        datasource db {
+          provider = "sqlite"
+          url      = "file:./dev.db"
+        }
+      `,
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "prisma:sqlite",
+      database: "sqlite",
+      packageJsonPath: "schema.prisma",
+      field: "dependencies",
+    });
+  });
+
+  test("detects node:sqlite imports in source files", () => {
+    const files: Files = {
+      "src/db.ts": `import { DatabaseSync } from "node:sqlite";`,
+    };
+    const result = extractDbLibrariesUsed({ files });
+    expect(result).toContainEqual({
+      library: "node:sqlite",
+      database: "sqlite",
+      packageJsonPath: "src/db.ts",
+      field: "dependencies",
+    });
+  });
+
   test("detects libraries listed in devDependencies", () => {
     const files: Files = {
       "package.json": packageJson({

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
@@ -58,6 +58,7 @@ export const DB_LIBRARIES: Record<string, PrimaryDatabase | null> = {
   // SQLite / libSQL (Turso)
   sqlite3: "sqlite",
   "better-sqlite3": "sqlite",
+  "sql.js": "sqlite",
   "node:sqlite": "sqlite",
   "@libsql/client": "turso",
   libsql: "turso",

--- a/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/utils/extractDbLibrariesUsed.ts
@@ -165,6 +165,47 @@ function lookupDatabase(
 
 const DEPENDENCY_FIELDS = ["dependencies", "devDependencies"] as const;
 
+const SOURCE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+];
+
+const PRISMA_PROVIDER_TO_DATABASE: Record<string, PrimaryDatabase> = {
+  postgresql: "postgresql",
+  postgres: "postgresql",
+  mysql: "mysql",
+  sqlite: "sqlite",
+  mongodb: "mongodb",
+  sqlserver: "mssql",
+  cockroachdb: "cockroachdb",
+};
+
+function isPrismaSchema(path: string): boolean {
+  return path === "schema.prisma" || path.endsWith(".prisma");
+}
+
+function isSourceFile(path: string): boolean {
+  return SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext));
+}
+
+function extractPrismaProviders(content: string): string[] {
+  return [...content.matchAll(/\bprovider\s*=\s*"([^"]+)"/g)].map(
+    ([, provider]) => provider
+  );
+}
+
+function sourceImportsNodeSqlite(content: string): boolean {
+  return (
+    /\bfrom\s+["']node:sqlite["']/.test(content) ||
+    /\bimport\s+["']node:sqlite["']/.test(content) ||
+    /\brequire\(["']node:sqlite["']\)/.test(content)
+  );
+}
+
 /**
  * Inspect every `package.json` in the generated files and report which
  * database libraries appear in their `dependencies` / `devDependencies`.
@@ -180,6 +221,30 @@ export function extractDbLibrariesUsed({
   const detected: DetectedDbLibrary[] = [];
 
   for (const [path, content] of Object.entries(files)) {
+    if (isPrismaSchema(path)) {
+      for (const provider of extractPrismaProviders(content)) {
+        const database = PRISMA_PROVIDER_TO_DATABASE[provider];
+        if (!database) continue;
+        detected.push({
+          library: `prisma:${provider}`,
+          database,
+          packageJsonPath: path,
+          field: "dependencies",
+        });
+      }
+      continue;
+    }
+
+    if (isSourceFile(path) && sourceImportsNodeSqlite(content)) {
+      detected.push({
+        library: "node:sqlite",
+        database: "sqlite",
+        packageJsonPath: path,
+        field: "dependencies",
+      });
+      continue;
+    }
+
     if (!isPackageJson(path)) continue;
 
     let parsed: unknown;

--- a/packages/mongodb-rag-core/src/models/models.ts
+++ b/packages/mongodb-rag-core/src/models/models.ts
@@ -602,7 +602,17 @@ const allModels = [
   },
   {
     label: "azure/claude-sonnet-4-6",
-    deployment: "claude-sonnet-4-6",
+    deployment: "azure-claude-sonnet-4-6",
+    developer: "Anthropic",
+    maxConcurrency: 5,
+    provider: "braintrust",
+    authorized: true,
+    reasoning: true,
+    host: "Microsoft Azure",
+  },
+  {
+    label: "azure/claude-haiku-4-5",
+    deployment: "claude-haiku-4-5",
     developer: "Anthropic",
     maxConcurrency: 5,
     provider: "braintrust",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-1975

## Changes

- Add coding agent app-development harness support for Claude Code, Codex/OpenAI, and opencode-style sandbox runs.
- Expand sandbox generation handling, prompt/config wiring, and app-development task tests.
- Add MongoDB library detection coverage and benchmark model metadata updates.

## Notes

Can run with command like:

```sh
npm run benchmark -- run \
  --type coding_agent_app_development \
  --task opencode/opencode \
  --model azure/claude-haiku-4-5 \
  --dataset db_agnostic \
  --sampleSize 3 \
  --sampleType firstN \
  --taskConcurrency 1 \
  --modelConcurrency 1
```

