### PR TITLE
Avoid stateful regex reuse in transcript metric

### DIFF
--- a/packages/benchmarks/src/benchmarkModels.ts
+++ b/packages/benchmarks/src/benchmarkModels.ts
@@ -43,6 +43,7 @@ export const MODELS = (
     "mistral-large-2",
     "azure/claude-sonnet-4-6",
     "azure/claude-haiku-4-5",
+    "azure/deepseek-v4-pro",
   ] satisfies (typeof models)[number]["label"][]
 ).map((label) => {
   const model = models.find((m) => m.label === label);

--- a/packages/benchmarks/src/benchmarkModels.ts
+++ b/packages/benchmarks/src/benchmarkModels.ts
@@ -43,7 +43,6 @@ export const MODELS = (
     "mistral-large-2",
     "azure/claude-sonnet-4-6",
     "azure/claude-haiku-4-5",
-    "azure/deepseek-v4-pro",
   ] satisfies (typeof models)[number]["label"][]
 ).map((label) => {
   const model = models.find((m) => m.label === label);

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.test.ts
@@ -75,8 +75,12 @@ describe("MongoDbInCode", () => {
     ).toBe(0);
   });
 
-  test("scores 0 when there are no files", () => {
-    expect(runMongoDbInCode({}).score).toBe(0);
+  test("does not score when there are no files", () => {
+    const result = runMongoDbInCode({});
+
+    expect(result.name).toBe("MongoDbInCode");
+    expect(result.score).toBeNull();
+    expect(result.metadata?.matchedFiles).toEqual([]);
   });
 
   test("includes matched files in metadata", () => {

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInCode.ts
@@ -45,7 +45,7 @@ function fileImportsMongoDb(content: string): string[] {
  * Checks whether MongoDB is used in the generated code by detecting whether a
  * MongoDB library / driver / ODM is imported into any source file.
  *
- * Returns 1 if MongoDB is imported in the application, otherwise 0.
+ * Returns 1 if MongoDB is imported in the application, 0 if not, and null if there are no files.
  */
 export const MongoDbInCode: CodingAgentAppDevelopmentEvalScorer = ({
   output,
@@ -53,7 +53,17 @@ export const MongoDbInCode: CodingAgentAppDevelopmentEvalScorer = ({
   const files = output?.files ?? {};
 
   const matchedFiles: Array<{ path: string; patterns: string[] }> = [];
-  for (const [path, content] of Object.entries(files)) {
+  const fileEntries = Object.entries(files);
+
+  if (fileEntries.length === 0) {
+    return {
+      name: "MongoDbInCode",
+      score: null,
+      metadata: { matchedFiles: [] },
+    };
+  }
+
+  for (const [path, content] of fileEntries) {
     if (!isSourceFile(path)) continue;
     const patterns = fileImportsMongoDb(content);
     if (patterns.length > 0) matchedFiles.push({ path, patterns });

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
@@ -1,4 +1,5 @@
 import { MongoDbInTranscript } from "./MongoDbInTranscript";
+import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbInGeneration";
 
 function score(transcript: string) {
   return MongoDbInTranscript({
@@ -7,6 +8,12 @@ function score(transcript: string) {
 }
 
 describe("MongoDbInTranscript", () => {
+  const originalPatternCount = MONGODB_PATTERNS.length;
+
+  afterEach(() => {
+    MONGODB_PATTERNS.splice(originalPatternCount);
+  });
+
   test("scores 1 when transcript mentions 'mongodb'", () => {
     const result = score("I'll use MongoDB for the database.");
     expect(result.name).toBe("MongoDbInTranscript");
@@ -38,5 +45,12 @@ describe("MongoDbInTranscript", () => {
   test("includes matched patterns in metadata", () => {
     const result = score("Use mongoose to connect to mongodb");
     expect(result.metadata?.matchedPatterns?.length).toBeGreaterThan(1);
+  });
+
+  test("does not reuse lastIndex from stateful patterns", () => {
+    MONGODB_PATTERNS.push(/mongo/gi);
+
+    expect(score("mongo").score).toBe(1);
+    expect(score("mongo").score).toBe(1);
   });
 });

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.test.ts
@@ -4,7 +4,7 @@ import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbI
 function score(transcript: string) {
   return MongoDbInTranscript({
     output: { transcript, files: {} },
-  } as any) as { name: string; score: number; metadata?: any };
+  } as any) as { name: string; score: number | null; metadata?: any };
 }
 
 describe("MongoDbInTranscript", () => {
@@ -38,8 +38,12 @@ describe("MongoDbInTranscript", () => {
     ).toBe(0);
   });
 
-  test("scores 0 for an empty transcript", () => {
-    expect(score("").score).toBe(0);
+  test("does not score an empty transcript", () => {
+    const result = score("");
+
+    expect(result.name).toBe("MongoDbInTranscript");
+    expect(result.score).toBeNull();
+    expect(result.metadata?.matchedPatterns).toEqual([]);
   });
 
   test("includes matched patterns in metadata", () => {

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
@@ -7,12 +7,21 @@ import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbI
  *
  * Reuses the MongoDB patterns from {@link MONGODB_PATTERNS}.
  *
- * Returns 1 if MongoDB is mentioned, otherwise 0.
+ * Returns 1 if MongoDB is mentioned, 0 if not, and null if the transcript is empty.
  */
 export const MongoDbInTranscript: CodingAgentAppDevelopmentEvalScorer = ({
   output,
 }) => {
   const transcript = output.transcript;
+
+  // Do not score if the transcript is empty.
+  if (transcript === "") {
+    return {
+      name: "MongoDbInTranscript",
+      score: null,
+      metadata: { matchedPatterns: [] },
+    };
+  }
 
   const matchedPatterns = MONGODB_PATTERNS.filter((pattern) =>
     new RegExp(pattern.source, pattern.flags).test(transcript)

--- a/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/metrics/MongoDbInTranscript.ts
@@ -12,10 +12,10 @@ import { MONGODB_PATTERNS } from "../../app-development/metrics/MentionsMongoDbI
 export const MongoDbInTranscript: CodingAgentAppDevelopmentEvalScorer = ({
   output,
 }) => {
-  const transcript = output?.transcript ?? "";
+  const transcript = output.transcript;
 
   const matchedPatterns = MONGODB_PATTERNS.filter((pattern) =>
-    pattern.test(transcript)
+    new RegExp(pattern.source, pattern.flags).test(transcript)
   ).map((pattern) => pattern.source);
 
   return {


### PR DESCRIPTION
Jira: N/A

## Changes

- Evaluate MongoDB transcript patterns with fresh `RegExp` instances so stateful patterns cannot reuse `lastIndex`.
- Clarify in code the `output.transcript` is never undefined, always a string
- Do not score when output items are empty (`transcript=""` or `files={}`)

## Notes

- Added a regression test that appends a global MongoDB pattern and verifies repeated scorer calls still pass.