### PR TITLE
EAI-2136: task variants + opencode agent plan variant

### DIFF
--- a/packages/benchmarks/src/cli/BenchmarkConfig.ts
+++ b/packages/benchmarks/src/cli/BenchmarkConfig.ts
@@ -13,6 +13,10 @@ export interface BenchmarkDataset<Input, Expected, Metadata> {
   getDataset: () => Promise<EvalCase<Input, Expected, Metadata>[]>;
 }
 
+interface BenchmarkTaskVariant {
+  name: string;
+  description?: string;
+}
 export interface BenchmarkTask<
   Input,
   Output,
@@ -20,9 +24,11 @@ export interface BenchmarkTask<
   Metadata extends BaseMetadata = DefaultMetadataType,
   Parameters extends EvalParameters = EvalParameters
 > {
+  variants?: BenchmarkTaskVariant[];
   taskFunc: (
     modelProvider: ModelProvider,
-    deployment: ModelConfig
+    deployment: ModelConfig,
+    variant?: BenchmarkTaskVariant
   ) =>
     | Promise<EvalTask<Input, Output, Expected, Metadata, Parameters>>
     | EvalTask<Input, Output, Expected, Metadata, Parameters>;

--- a/packages/benchmarks/src/cli/benchmarkCli.test.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.test.ts
@@ -56,6 +56,16 @@ describe("makeBenchmarkCli", () => {
           tasks: {
             task1: {
               description: "Test task 1",
+              variants: [
+                {
+                  name: "variant-a",
+                  description: "Test variant A",
+                },
+                {
+                  name: "variant-b",
+                  description: "Test variant B",
+                },
+              ],
               taskFunc: jest.fn(),
             },
             task2: {
@@ -131,6 +141,61 @@ describe("makeBenchmarkCli", () => {
         "dataset1",
         "--task",
         "unknown-task",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate unknown variant", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "dataset1",
+        "--task",
+        "task1",
+        "--variant",
+        "unknown-variant",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate unknown variant against default task", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "dataset1",
+        "--variant",
+        "unknown-variant",
+      ]);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should validate variant on task with no variants", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--model",
+        "test-model-1",
+        "--dataset",
+        "dataset1",
+        "--task",
+        "task2",
+        "--variant",
+        "variant-a",
       ]);
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
@@ -318,6 +383,36 @@ describe("makeBenchmarkCli", () => {
       expect(mockRunBenchmark).toHaveBeenCalledWith(mockConfig, {
         type: "test-benchmark",
         task: "task1",
+        variant: undefined,
+        models: mockConfig.models,
+        datasets: ["dataset1"],
+        modelConcurrency: 2,
+        sampleSize: undefined,
+        sampleType: undefined,
+        taskConcurrency: undefined,
+        trialCount: 1,
+      });
+    });
+
+    it("should pass variant to runBenchmark", async () => {
+      const cli = makeBenchmarkCli(mockConfig);
+
+      await cli.parse([
+        "run",
+        "--type",
+        "test-benchmark",
+        "--dataset",
+        "dataset1",
+        "--task",
+        "task1",
+        "--variant",
+        "variant-a",
+      ]);
+
+      expect(mockRunBenchmark).toHaveBeenCalledWith(mockConfig, {
+        type: "test-benchmark",
+        task: "task1",
+        variant: "variant-a",
         models: mockConfig.models,
         datasets: ["dataset1"],
         modelConcurrency: 2,
@@ -363,6 +458,7 @@ describe("makeBenchmarkCli", () => {
       expect(mockRunBenchmark).toHaveBeenCalledWith(mockConfig, {
         type: "test-benchmark",
         task: "task1", // First task
+        variant: undefined,
         models: mockConfig.models, // All models
         datasets: ["dataset1"],
         modelConcurrency: 2,
@@ -394,6 +490,7 @@ describe("makeBenchmarkCli", () => {
       expect(mockRunBenchmark).toHaveBeenCalledWith(mockConfig, {
         type: "test-benchmark",
         task: "task1",
+        variant: undefined,
         models: [mockConfig.models[0]], // Only test-model-1
         datasets: ["dataset1", "dataset2"],
         modelConcurrency: 1,
@@ -453,8 +550,17 @@ describe("makeBenchmarkCli", () => {
                 dataset2: "Test dataset 2",
               },
               tasks: {
-                task1: "Test task 1",
-                task2: "Test task 2",
+                task1: {
+                  description: "Test task 1",
+                  variants: {
+                    "variant-a": "Test variant A",
+                    "variant-b": "Test variant B",
+                  },
+                },
+                task2: {
+                  description: "Test task 2",
+                  variants: {},
+                },
               },
               scorers: {
                 scorer1: "Test scorer 1",

--- a/packages/benchmarks/src/cli/benchmarkCli.ts
+++ b/packages/benchmarks/src/cli/benchmarkCli.ts
@@ -31,6 +31,10 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
             describe:
               "Tasks to run per benchmark. Defaults to first provided task for type.",
           })
+          .option("variant", {
+            type: "string",
+            describe: "Variant of task to run. Defaults to none.",
+          })
           .option("sampleSize", {
             type: "number",
             describe:
@@ -76,6 +80,23 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               errors.push(
                 `Unknown task: ${argv.task}. Use 'benchmark list' to see available tasks for type ${argv.type}.`
               );
+            }
+
+            const defaultTaskName = Object.keys(
+              config.benchmarks[argv.type]?.tasks ?? {}
+            )[0];
+
+            const taskName = argv.task ?? defaultTaskName;
+
+            // Validate that the task variant exists for the task
+            if (argv.variant) {
+              const variants =
+                config.benchmarks[argv.type]?.tasks[taskName]?.variants;
+              if (!variants?.some((v) => v.name === argv.variant)) {
+                errors.push(
+                  `Unknown variant for task: ${taskName} - ${argv.variant}. Use 'benchmark list' to see available variants for tasks ${taskName}.`
+                );
+              }
             }
 
             // Validate datasets exist
@@ -134,10 +155,7 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               errors.push("sampleSize must be a positive integer");
             }
 
-            if (
-              !Number.isInteger(argv.trialCount) ||
-              argv.trialCount < 1
-            ) {
+            if (!Number.isInteger(argv.trialCount) || argv.trialCount < 1) {
               errors.push("trialCount must be a positive integer");
             }
 
@@ -150,9 +168,10 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
       },
       async (argv) => {
         try {
-          const tasks = argv.task
-            ? [argv.task]
-            : Object.keys(config.benchmarks[argv.type].tasks);
+          const defaultTaskName = Object.keys(
+            config.benchmarks[argv.type].tasks
+          )[0];
+          const task = argv.task ? argv.task : defaultTaskName;
           const datasets = argv.dataset
             ? argv.dataset
             : [Object.keys(config.benchmarks[argv.type].datasets)[0]];
@@ -161,7 +180,8 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
             : config.models.map((m) => m.label);
           const args: RunBenchmarkArgs = {
             type: argv.type,
-            task: argv.task ?? tasks[0],
+            task,
+            variant: argv.variant,
             models: config.models.filter((m) => models.includes(m.label)),
             datasets,
             taskConcurrency: argv.taskConcurrency,
@@ -190,7 +210,14 @@ export function makeBenchmarkCli(config: BenchmarkCliConfig) {
               .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
             tasks: Object.entries(benchmarkConfig.tasks)
               .map(([name, task]) => ({
-                [name]: task.description ?? "",
+                [name]: {
+                  description: task.description ?? "",
+                  variants: (task.variants ?? [])
+                    .map((v) => ({
+                      [v.name]: v.description ?? "",
+                    }))
+                    .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
+                },
               }))
               .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
             scorers: Object.entries(benchmarkConfig.scorers)

--- a/packages/benchmarks/src/cli/runBenchmark.test.ts
+++ b/packages/benchmarks/src/cli/runBenchmark.test.ts
@@ -89,6 +89,16 @@ describe("runBenchmark", () => {
           tasks: {
             task1: {
               description: "Test task 1",
+              variants: [
+                {
+                  name: "variant-a",
+                  description: "Test variant A",
+                },
+                {
+                  name: "variant-b",
+                  description: "Test variant B",
+                },
+              ],
               taskFunc: mockTaskFunc,
             },
             task2: {
@@ -172,6 +182,26 @@ describe("runBenchmark", () => {
 
       await expect(runBenchmark(mockConfig, invalidArgs)).rejects.toThrow(
         "No valid tasks found"
+      );
+    });
+
+    it("should throw error for unknown variant", async () => {
+      const invalidArgs = { ...mockArgs, variant: "unknown-variant" };
+
+      await expect(runBenchmark(mockConfig, invalidArgs)).rejects.toThrow(
+        "Variant for task does not exist: task1 - unknown-variant"
+      );
+    });
+
+    it("should throw error when variant provided for task with no variants", async () => {
+      const invalidArgs = {
+        ...mockArgs,
+        task: "task2",
+        variant: "variant-a",
+      };
+
+      await expect(runBenchmark(mockConfig, invalidArgs)).rejects.toThrow(
+        "Variant for task does not exist: task2 - variant-a"
       );
     });
 
@@ -284,6 +314,19 @@ describe("runBenchmark", () => {
         experimentType: "task1",
         datasets: "dataset1",
         model: expect.any(String),
+        variant: "none",
+      });
+    });
+
+    it("should create experiment name with variant when provided", async () => {
+      await runBenchmark(mockConfig, { ...mockArgs, variant: "variant-a" });
+
+      expect(mockMakeExperimentName).toHaveBeenCalledWith({
+        baseName: "test-benchmark",
+        experimentType: "task1",
+        datasets: "dataset1",
+        model: expect.any(String),
+        variant: "variant-a",
       });
     });
 
@@ -300,6 +343,7 @@ describe("runBenchmark", () => {
         experimentType: "task1",
         datasets: "dataset1+dataset2",
         model: expect.any(String),
+        variant: "none",
       });
     });
 
@@ -315,11 +359,25 @@ describe("runBenchmark", () => {
           task: "task1",
           dataset: "dataset1",
           taskConcurrency: undefined,
+          variant: "none",
         },
         task: "mock-task-result",
         scores: [mockScorerFunc],
         trialCount: undefined,
       });
+    });
+
+    it("should pass variant to Eval metadata when provided", async () => {
+      await runBenchmark(mockConfig, { ...mockArgs, variant: "variant-a" });
+
+      expect(mockEval).toHaveBeenCalledWith(
+        "test-project",
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            variant: "variant-a",
+          }),
+        })
+      );
     });
 
     it("should pass trialCount to Eval when provided", async () => {
@@ -493,7 +551,15 @@ describe("runBenchmark", () => {
         "Model(s): test-model-1, test-model-2"
       );
       expect(consoleLogSpy).toHaveBeenCalledWith("Dataset(s): dataset1");
+      expect(consoleLogSpy).toHaveBeenCalledWith("Task: task1");
+      expect(consoleLogSpy).toHaveBeenCalledWith("Variant: none");
       expect(consoleLogSpy).toHaveBeenCalledWith("Model concurrency: 2");
+    });
+
+    it("should log variant name when provided", async () => {
+      await runBenchmark(mockConfig, { ...mockArgs, variant: "variant-a" });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith("Variant: variant-a");
     });
 
     it("should log experiment progress", async () => {
@@ -689,7 +755,21 @@ describe("runBenchmark", () => {
 
       expect(mockTaskFunc).toHaveBeenCalledWith(
         mockConfig.modelProvider,
-        mockConfig.models[0]
+        mockConfig.models[0],
+        undefined
+      );
+    });
+
+    it("should call task function with variant when provided", async () => {
+      await runBenchmark(mockConfig, { ...mockArgs, variant: "variant-a" });
+
+      expect(mockTaskFunc).toHaveBeenCalledWith(
+        mockConfig.modelProvider,
+        mockConfig.models[0],
+        {
+          name: "variant-a",
+          description: "Test variant A",
+        }
       );
     });
 
@@ -698,12 +778,14 @@ describe("runBenchmark", () => {
 
       expect(mockTaskFunc).toHaveBeenCalledWith(
         mockConfig.modelProvider,
-        mockConfig.models[0]
+        mockConfig.models[0],
+        undefined
       );
 
       expect(mockTaskFunc).toHaveBeenCalledWith(
         mockConfig.modelProvider,
-        mockConfig.models[1]
+        mockConfig.models[1],
+        undefined
       );
     });
 

--- a/packages/benchmarks/src/cli/runBenchmark.ts
+++ b/packages/benchmarks/src/cli/runBenchmark.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "assert";
 export interface RunBenchmarkArgs {
   type: string;
   task: string;
+  variant?: string;
   models: ModelConfig[];
   datasets: string[];
   taskConcurrency?: number;
@@ -22,6 +23,7 @@ export async function runBenchmark(
   {
     type,
     task,
+    variant,
     models,
     datasets,
     taskConcurrency,
@@ -54,10 +56,16 @@ export async function runBenchmark(
     throw new Error("No valid tasks found");
   }
 
+  const taskVariant = taskToRun.variants?.find((v) => v.name === variant);
+  if (variant && !taskVariant) {
+    throw new Error(`Variant for task does not exist: ${task} - ${variant}`);
+  }
+
   console.log(`Running benchmark: ${type}`);
   console.log(`Model(s): ${models.map((m) => m.label).join(", ")}`);
   console.log(`Dataset(s): ${datasetsToRun.map(([name]) => name).join(", ")}`);
   console.log(`Task: ${task}`);
+  console.log(`Variant: ${taskVariant?.name ?? "none"}`);
   console.log(`Model concurrency: ${modelConcurrency}`);
 
   // Setup environment
@@ -95,6 +103,7 @@ export async function runBenchmark(
           experimentType: task,
           datasets: datasetName,
           model: model.label,
+          variant: taskVariant?.name ?? "none",
         });
 
         console.log(`Running experiment: ${experimentName}`);
@@ -115,8 +124,9 @@ export async function runBenchmark(
               task,
               dataset: datasetName,
               taskConcurrency,
+              variant: taskVariant?.name ?? "none",
             },
-            task: await taskToRun.taskFunc(config.modelProvider, model),
+            task: await taskToRun.taskFunc(config.modelProvider, model, taskVariant),
             scores,
             trialCount,
           });

--- a/packages/benchmarks/src/coding-agent-app-development/agents.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/agents.ts
@@ -1,18 +1,28 @@
 import assert from "assert";
 import { OUTPUT_DIR } from "./prompts";
 
+export type AgentVariant = "build" | "plan";
+
 export interface AgentConfig {
   id: string;
   /** 
      @example
      ["npm install -g @anthropic-ai/claude-code"]
    */
-  buildSetupCommands: (env: Record<string, string>, model: string) => string[];
+  buildSetupCommands: (
+    env: Record<string, string>,
+    model: string,
+    variant?: AgentVariant
+  ) => string[];
   /** 
      @example
      (promptFilePath, model) => `claude --print --model ${model} < ${promptFilePath}`
    */
-  buildMainCommand: (promptFilePath: string, model: string) => string;
+  buildMainCommand: (
+    promptFilePath: string,
+    model: string,
+    variant?: AgentVariant
+  ) => string;
 
   /** 
      @example
@@ -77,8 +87,14 @@ env_key = "OPENAI_API_KEY"
 env_http_headers = { "x-bt-parent" = "BRAINTRUST_PARENT" }
 EOF`,
     ],
-    buildMainCommand: (promptFilePath, model) =>
-      `codex exec --sandbox danger-full-access --skip-git-repo-check --model ${model} - < ${promptFilePath}`,
+    buildMainCommand: (promptFilePath, model, variant) => {
+      if (variant === "plan") {
+        throw new Error(
+          "Plan variant is not supported for running openai/codex headlessly"
+        );
+      }
+      return `codex exec --sandbox danger-full-access --skip-git-repo-check --model ${model} - < ${promptFilePath}`;
+    },
     env: {
       OPENAI_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
       OPENAI_API_KEY: process.env.BRAINTRUST_GATEWAY_API_KEY,
@@ -120,8 +136,15 @@ EOF`,
         )}\nEOF`,
       ];
     },
-    buildMainCommand: (promptFilePath, model) =>
-      `opencode run --dir ${OUTPUT_DIR} --model braintrust/${model} --dangerously-skip-permissions "Build the app described in the attached prompt file." --file ${promptFilePath}`,
+    buildMainCommand: (promptFilePath, model, variant) => {
+      // Plan agent denies non-plan file edits. Without
+      // --dangerously-skip-permissions, headless `opencode run` auto-rejects
+      // permission asks and the agent exits after one message.
+      if (variant === "plan") {
+        return `opencode run --dir ${OUTPUT_DIR} --model braintrust/${model} --agent plan --dangerously-skip-permissions "Create a detailed implementation plan for the app described in the attached prompt file. Do not implement the app yet." --file ${promptFilePath}`;
+      }
+      return `opencode run --dir ${OUTPUT_DIR} --model braintrust/${model} --dangerously-skip-permissions "Build the app described in the attached prompt file." --file ${promptFilePath}`;
+    },
     env: {
       OPENAI_BASE_URL: process.env.BRAINTRUST_ENDPOINT,
       OPENAI_API_KEY: process.env.BRAINTRUST_GATEWAY_API_KEY,

--- a/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/appDevelopmentTask.test.ts
@@ -69,6 +69,25 @@ describe("makeAppDevelopmentTask", () => {
     });
   });
 
+  test("forwards variant to generateAppInSandbox", async () => {
+    mockGenerateAppInSandbox.mockResolvedValue({
+      files: {},
+      databaseLibraries: [],
+      stdout: "",
+      stderr: "",
+    });
+    const args = { ...makeTaskArgs(), variant: "plan" as const };
+
+    const task = makeAppDevelopmentTask(args);
+    await task(makeInput(), makeMockHooks());
+
+    expect(mockGenerateAppInSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "plan",
+      })
+    );
+  });
+
   test("returns files, detected database libraries, and stdout transcript", async () => {
     const files = {
       "package.json": JSON.stringify({

--- a/packages/benchmarks/src/coding-agent-app-development/config.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/config.ts
@@ -9,7 +9,7 @@ import {
 import { loadAppDevelopmentDataset } from "./loadAppDevelopmentDataset";
 import { MongoDbInCode } from "./metrics/MongoDbInCode";
 import { MongoDbInTranscript } from "./metrics/MongoDbInTranscript";
-import { AGENTS } from "./agents";
+import { AGENTS, AgentVariant } from "./agents";
 import { BASE_SYSTEM_PROMPT } from "./prompts";
 
 type CodingAgentAppDevelopmentBenchmarkConfig = BenchmarkConfig<
@@ -19,17 +19,38 @@ type CodingAgentAppDevelopmentBenchmarkConfig = BenchmarkConfig<
   CodingAgentAppDevelopmentMetadata
 >;
 
+const AGENT_VARIANTS: { name: AgentVariant; description: string }[] = [
+  {
+    name: "build",
+    description: "Agent runs with full write access and implements the app",
+  },
+  {
+    name: "plan",
+    description:
+      "Agent runs in plan/read-only mode before or instead of implementing",
+  },
+];
+
+function asAgentVariant(name?: string): AgentVariant | undefined {
+  if (name === "build" || name === "plan") {
+    return name;
+  }
+  return undefined;
+}
+
 const tasksConfig: CodingAgentAppDevelopmentBenchmarkConfig["tasks"] =
   Object.fromEntries(
     AGENTS.map((agent) => [
       agent.id,
       {
         description: `Runs ${agent.id} coding agent in a sandbox`,
-        taskFunc: (_modelProvider, modelConfig) =>
+        variants: AGENT_VARIANTS,
+        taskFunc: (_modelProvider, modelConfig, variant) =>
           makeAppDevelopmentTask({
             agent,
             model: modelConfig.deployment,
             systemPrompt: BASE_SYSTEM_PROMPT,
+            variant: asAgentVariant(variant?.name),
           }),
       },
     ])

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.test.ts
@@ -267,7 +267,36 @@ describe("generateAppInSandbox", () => {
         AGENT_API_KEY: "test-key",
         BRAINTRUST_PARENT: "span-export-value",
       },
-      "test-model"
+      "test-model",
+      undefined
+    );
+  });
+
+  test("passes variant through to agent setup and main commands", async () => {
+    const agent = makeAgentConfig({
+      setupCommands: ["install agent"],
+      mainCommand: "run agent",
+    });
+    const sandbox = makeMockSandbox();
+    mockCreateSandbox.mockResolvedValue(sandbox as Sandbox);
+
+    await generateAppInSandbox({
+      agent,
+      model: "test-model",
+      systemPrompt: "Build complete apps.",
+      input: makeInput(),
+      variant: "plan",
+    });
+
+    expect(agent.buildSetupCommands).toHaveBeenCalledWith(
+      agent.env,
+      "test-model",
+      "plan"
+    );
+    expect(agent.buildMainCommand).toHaveBeenCalledWith(
+      "/tmp/claude-prompt.txt",
+      "test-model",
+      "plan"
     );
   });
 
@@ -309,7 +338,8 @@ describe("generateAppInSandbox", () => {
 
     expect(agent.buildSetupCommands).toHaveBeenCalledWith(
       agent.env,
-      "test-model"
+      "test-model",
+      undefined
     );
     expect(sandbox.runCommand).toHaveBeenNthCalledWith(2, "sh", [
       "-c",
@@ -358,7 +388,8 @@ Use MongoDB for storage.
     ]);
     expect(agent.buildMainCommand).toHaveBeenCalledWith(
       "/tmp/claude-prompt.txt",
-      "gpt-test"
+      "gpt-test",
+      undefined
     );
   });
 

--- a/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
+++ b/packages/benchmarks/src/coding-agent-app-development/generateAppInSandbox.ts
@@ -2,7 +2,7 @@ import { Sandbox } from "@vercel/sandbox";
 import { CodingAgentAppDevelopmentEvalCaseInput } from "./CodingAgentAppDevelopmentEval";
 import { extractDbLibrariesUsed, extractFilesFromSandbox } from "./utils";
 import assert from "assert";
-import { type AgentConfig } from "./agents";
+import { type AgentConfig, type AgentVariant } from "./agents";
 import { OUTPUT_DIR } from "./prompts";
 
 const PROMPT_FILE_PATH = "/tmp/claude-prompt.txt";
@@ -24,6 +24,7 @@ export interface GenerateAppInSandboxParams {
   systemPrompt: string;
   input: CodingAgentAppDevelopmentEvalCaseInput;
   braintrustParent?: string;
+  variant?: AgentVariant;
 }
 
 function makeSandboxEnv({
@@ -48,6 +49,7 @@ export const generateAppInSandbox = async function ({
   systemPrompt,
   input,
   braintrustParent,
+  variant,
 }: GenerateAppInSandboxParams) {
   assertSandboxEnv();
   const prompt = buildFullPrompt(systemPrompt, input);
@@ -76,7 +78,7 @@ export const generateAppInSandbox = async function ({
     });
 
     // setup agent in sandbox
-    const setupCommands = agent.buildSetupCommands(sandboxEnv, model);
+    const setupCommands = agent.buildSetupCommands(sandboxEnv, model, variant);
     for (const setupCmd of setupCommands) {
       await sandbox.runCommand("sh", ["-c", setupCmd]);
     }
@@ -89,7 +91,11 @@ export const generateAppInSandbox = async function ({
     ]);
 
     // run agent!
-    const fullCommand = agent.buildMainCommand(PROMPT_FILE_PATH, model);
+    const fullCommand = agent.buildMainCommand(
+      PROMPT_FILE_PATH,
+      model,
+      variant
+    );
     const command = await sandbox.runCommand({
       cmd: "sh",
       args: ["-c", fullCommand],


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EAI-2136

## Changes

- Add support for task variants to eval cli
- Add OpenCode coding agent task variant for 'plan' mode

## Notes

-
